### PR TITLE
Add a shortcut to open a properties window

### DIFF
--- a/src/core/m_symbols.c
+++ b/src/core/m_symbols.c
@@ -163,6 +163,7 @@ t_symbol *sym__pgmin;
 t_symbol *sym__polling;
 t_symbol *sym__polytouchin;
 t_symbol *sym__popupdialog;
+t_symbol *sym__properties;
 t_symbol *sym__quit;
 t_symbol *sym__savepreferences;
 t_symbol *sym__savetofile;
@@ -822,6 +823,7 @@ void symbols_initialize (void)
     sym__polling                                = gensym ("_polling");
     sym__polytouchin                            = gensym ("_polytouchin");
     sym__popupdialog                            = gensym ("_popupdialog");
+    sym__properties                             = gensym ("_properties");
     sym__quit                                   = gensym ("_quit");
     sym__savepreferences                        = gensym ("_savepreferences");
     sym__savetofile                             = gensym ("_savetofile");

--- a/src/core/m_symbols.h
+++ b/src/core/m_symbols.h
@@ -163,6 +163,7 @@ extern t_symbol *sym__pgmin;
 extern t_symbol *sym__polling;
 extern t_symbol *sym__polytouchin;
 extern t_symbol *sym__popupdialog;
+extern t_symbol *sym__properties;
 extern t_symbol *sym__quit;
 extern t_symbol *sym__savepreferences;
 extern t_symbol *sym__savetofile;

--- a/src/graphics/patch/g_canvas.c
+++ b/src/graphics/patch/g_canvas.c
@@ -236,6 +236,19 @@ static void canvas_map (t_glist *glist, t_float f)
     glist_windowMapped (glist, (f != 0.0));
 }
 
+static void canvas_properties (t_glist *glist)
+{
+    if (glist_objectGetNumberOfSelected (glist) > 0) {
+        t_selection *s = NULL;
+        for (s = editor_getSelection (glist_getEditor (glist)); s; s = selection_getNext (s)) {
+            t_gobj *y = selection_getObject (s);
+            if (class_hasPropertiesFunction (pd_class (y))) {
+                (*class_getPropertiesFunction (pd_class (y))) (y, glist);
+            }
+        }
+    } else { canvas_functionProperties (cast_gobj (glist), NULL); }
+}
+
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
@@ -515,6 +528,7 @@ void canvas_setup (void)
     class_addMethod (c, (t_method)canvas_snap,                  sym__snap,              A_NULL);
     class_addMethod (c, (t_method)canvas_bringToFront,          sym__front,             A_NULL);
     class_addMethod (c, (t_method)canvas_sendToBack,            sym__back,              A_NULL);
+    class_addMethod (c, (t_method)canvas_properties,            sym__properties,        A_NULL);
     
     class_addMethod (c, (t_method)canvas_requireArrayDialog,    sym__array,             A_NULL);
     class_addMethod (c, (t_method)canvas_fromPopupDialog,       sym__popupdialog,       A_GIMME, A_NULL);

--- a/tcl/ui_bind.tcl
+++ b/tcl/ui_bind.tcl
@@ -76,6 +76,7 @@ proc initialize {} {
     event add <<SelectAll>>                 <$mod-Key-a>
     event add <<EditMode>>                  <$mod-Key-e>
     event add <<ClearConsole>>              <$mod-Key-l>
+    event add <<Properties>>                <$mod-Key-i>
     event add <<Snap>>                      <$mod-Key-y>
     event add <<NewFile>>                   <$mod-Key-n>
     event add <<OpenFile>>                  <$mod-Key-o>
@@ -191,6 +192,8 @@ proc bindPatch {top} {
     bind $top.c <Shift-MouseWheel>          { ::ui_patch::scroll %W x %D }
     bind $top.c <Destroy>                   { ::ui_patch::closed [winfo toplevel %W] }
     
+    bind $top.c <<Properties>>              { ::ui_bind::_properties %W }
+    
     wm protocol $top WM_DELETE_WINDOW       "::ui_patch::willClose $top"
 }
 
@@ -273,6 +276,15 @@ proc _mouseUp {c x y} {
     }
     
     set isResizing 0
+}
+
+# ------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------------------------------
+
+proc _properties {c} {
+
+    set top [winfo toplevel $c]
+    ::ui_interface::pdsend "$top _properties"
 }
 
 # ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #3 

## Proposed Changes

  - Add a Cmd-I (Ctrl-I) shortcut to open the properties window for selected objects.
  - In case no objects are selected, the patch's inspector is opened.
 