### PR TITLE
Make popup menu behaviour the same between platform

### DIFF
--- a/tcl/ui_menu.tcl
+++ b/tcl/ui_menu.tcl
@@ -166,7 +166,7 @@ proc showPopup {top xcanvas ycanvas hasProperties hasOpen hasHelp hasObject hasO
     set xpopup [expr {int([winfo rootx $top.c] + $xcanvas - [$top.c canvasx 0])}]
     set ypopup [expr {int([winfo rooty $top.c] + $ycanvas - [$top.c canvasy 0])}]
         
-    tk_popup .popup $xpopup $ypopup 0
+    tk_popup .popup $xpopup $ypopup
 
     }
 }


### PR DESCRIPTION
## Proposed Changes

On GNU/Linux (at least Ubuntu / Debian) releasing the right-click button triggers the first item. 
On macOS it doesn't. 
It is very annoying while switching from one platform to the other (at least for me).
This minor change makes the GNU/Linux version similar to macOS.
 

