### PR TITLE
Add shortcut to open help file

### DIFF
--- a/src/core/m_symbols.c
+++ b/src/core/m_symbols.c
@@ -141,6 +141,7 @@ t_symbol *sym__front;
 t_symbol *sym__gatomdialog;
 t_symbol *sym__graph;
 t_symbol *sym__grid;
+t_symbol *sym__help;
 t_symbol *sym__iemdialog;
 t_symbol *sym__inlet2;
 t_symbol *sym__inlet3;
@@ -801,6 +802,7 @@ void symbols_initialize (void)
     sym__gatomdialog                            = gensym ("_gatomdialog");
     sym__graph                                  = gensym ("_graph");
     sym__grid                                   = gensym ("_grid");
+    sym__help                                   = gensym ("_help");
     sym__iemdialog                              = gensym ("_iemdialog");
     sym__inlet2                                 = gensym ("_inlet2");
     sym__inlet3                                 = gensym ("_inlet3");

--- a/src/core/m_symbols.h
+++ b/src/core/m_symbols.h
@@ -141,6 +141,7 @@ extern t_symbol *sym__front;
 extern t_symbol *sym__gatomdialog;
 extern t_symbol *sym__graph;
 extern t_symbol *sym__grid;
+extern t_symbol *sym__help;
 extern t_symbol *sym__iemdialog;
 extern t_symbol *sym__inlet2;
 extern t_symbol *sym__inlet3;

--- a/src/graphics/patch/g_canvas.c
+++ b/src/graphics/patch/g_canvas.c
@@ -236,6 +236,10 @@ static void canvas_map (t_glist *glist, t_float f)
     glist_windowMapped (glist, (f != 0.0));
 }
 
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
 static void canvas_properties (t_glist *glist)
 {
     if (glist_objectGetNumberOfSelected (glist) > 0) {
@@ -247,6 +251,13 @@ static void canvas_properties (t_glist *glist)
             }
         }
     } else { canvas_functionProperties (cast_gobj (glist), NULL); }
+}
+
+static void canvas_help (t_glist *glist)
+{
+    if (glist_objectGetNumberOfSelected (glist) == 1) {
+        gobj_help (selection_getObject (editor_getSelection (glist_getEditor (glist))));
+    }
 }
 
 // -----------------------------------------------------------------------------------------------------------
@@ -536,6 +547,7 @@ void canvas_setup (void)
     class_addMethod (c, (t_method)canvas_bringToFront,          sym__front,             A_NULL);
     class_addMethod (c, (t_method)canvas_sendToBack,            sym__back,              A_NULL);
     class_addMethod (c, (t_method)canvas_properties,            sym__properties,        A_NULL);
+    class_addMethod (c, (t_method)canvas_help,                  sym__help,              A_NULL);
     
     class_addMethod (c, (t_method)canvas_requireArrayDialog,    sym__array,             A_NULL);
     class_addMethod (c, (t_method)canvas_fromPopupDialog,       sym__popupdialog,       A_GIMME, A_NULL);

--- a/tcl/ui_bind.tcl
+++ b/tcl/ui_bind.tcl
@@ -77,6 +77,7 @@ proc initialize {} {
     event add <<EditMode>>                  <$mod-Key-e>
     event add <<ClearConsole>>              <$mod-Key-l>
     event add <<Properties>>                <$mod-Key-i>
+    event add <<Help>>                      <$mod-Key-u>
     event add <<Snap>>                      <$mod-Key-y>
     event add <<NewFile>>                   <$mod-Key-n>
     event add <<OpenFile>>                  <$mod-Key-o>
@@ -193,6 +194,7 @@ proc bindPatch {top} {
     bind $top.c <Destroy>                   { ::ui_patch::closed [winfo toplevel %W] }
     
     bind $top.c <<Properties>>              { ::ui_bind::_properties %W }
+    bind $top.c <<Help>>                    { ::ui_bind::_help %W }
     
     wm protocol $top WM_DELETE_WINDOW       "::ui_patch::willClose $top"
 }
@@ -285,6 +287,12 @@ proc _properties {c} {
 
     set top [winfo toplevel $c]
     ::ui_interface::pdsend "$top _properties"
+}
+
+proc _help {c} {
+
+    set top [winfo toplevel $c]
+    ::ui_interface::pdsend "$top _help"
 }
 
 # ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Proposed Changes

  - Add a Cmd-U (Ctrl-U) shortcut to open the help patch for a selected object.
