### PR TITLE
Fix shortcut to close windows

### DIFF
--- a/tcl/ui_bind.tcl
+++ b/tcl/ui_bind.tcl
@@ -68,6 +68,7 @@ proc initialize {} {
     event add <<SendBack>>                  <Shift-$mod-Key-B>
     event add <<SaveAs>>                    <Shift-$mod-Key-S>
     event delete <<Paste>>                  <$mod-Key-y>
+    event delete <<Cut>>                    <$mod-Key-w>
     
     }
     


### PR DESCRIPTION
## Proposed Changes

  - Fix "Ctrl + W" shortcut to close windows (GNU/Linux).
  - By default it is bound to the Cut event ; deleted that.

