### PR TITLE
 Restore initial color in chooser

### DIFF
--- a/resources/help/acoustic.pdhelp
+++ b/resources/help/acoustic.pdhelp
@@ -4,7 +4,7 @@
 #X obj 36 192 rmstodb;
 #X obj 132 144 dbtopow;
 #X obj 132 192 powtodb;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 acoustic;
 #X obj -60 12 freeze;
 #X floatatom 228 108 5 0 0 1 - - -;

--- a/resources/help/acoustic~.pdhelp
+++ b/resources/help/acoustic~.pdhelp
@@ -8,7 +8,7 @@
 #X obj 168 192 rmstodb~;
 #X obj 300 168 dbtopow~;
 #X obj 300 192 powtodb~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 acoustic~;
 #X obj -60 12 freeze;
 #X floatatom 36 108 5 0 0 1 - - -;

--- a/resources/help/append.pdhelp
+++ b/resources/help/append.pdhelp
@@ -2,7 +2,7 @@
 #X obj 180 336 get;
 #X obj 216 336 set;
 #X obj 216 156 pointer;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 append;
 #X text 12 336 See also:;
 #X obj -60 12 freeze;

--- a/resources/help/arguments.pdhelp
+++ b/resources/help/arguments.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 565 111 337 292 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 252 See also:;
 #X obj 36 204 print;

--- a/resources/help/arithmetic.pdhelp
+++ b/resources/help/arithmetic.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 513 56 378 327 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -72 12 freeze;
 #X text 12 288 See also:;
 #X obj 120 288 mod;

--- a/resources/help/arithmetic~.pdhelp
+++ b/resources/help/arithmetic~.pdhelp
@@ -7,7 +7,7 @@
 #X obj 132 108 osc~ 675;
 #X obj 84 468 max~;
 #X obj 132 468 min~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 12 72 Basic arithmetic operators.;
 #X obj -60 12 freeze;
 #X text 24 24 arithmetic~;

--- a/resources/help/array.pdhelp
+++ b/resources/help/array.pdhelp
@@ -42,7 +42,7 @@
 #X obj 36 276 array random;
 #X obj 36 204 array max;
 #X obj 36 228 array min;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 array;
 #X text 12 504 See also:;
 #X text 168 108 Get or change size.;

--- a/resources/help/audio.pdhelp
+++ b/resources/help/audio.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 673 102 370 267 12;
 #X obj 36 132 adc~ 5;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X obj 36 156 dac~ 1 2 5;
 #X obj 36 108 dac~;

--- a/resources/help/bag.pdhelp
+++ b/resources/help/bag.pdhelp
@@ -3,7 +3,7 @@
 #X obj 36 204 print;
 #X obj 84 240 poly;
 #X text 12 240 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 bag;
 #N canvas 583 210 558 379 more 0;

--- a/resources/help/bang.pdhelp
+++ b/resources/help/bang.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 617 128 354 303 12;
 #X msg 36 108 45;
 #X obj 36 192 bang;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 bang;
 #X text 12 264 See also:;

--- a/resources/help/bang~.pdhelp
+++ b/resources/help/bang~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 750 164 300 254 12;
 #X obj 36 108 bang~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 bang~;
 #X obj -60 12 freeze;
 #X text 12 216 See also:;

--- a/resources/help/biquad~.pdhelp
+++ b/resources/help/biquad~.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 495 109 671 499 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 biquad~;
 #X obj 156 420 env~;

--- a/resources/help/bitwise.pdhelp
+++ b/resources/help/bitwise.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 593 146 471 410 12;
 #X obj 84 372 &&;
 #X obj 120 372 ||;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 bitwise;
 #X text 12 372 See also:;

--- a/resources/help/blockinfo~.pdhelp
+++ b/resources/help/blockinfo~.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 656 183 300 212 12;
 #X text 12 168 See also:;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 blockinfo~;
 #X obj 96 168 block~;
 #X text 12 72 Report block~ machinery.;

--- a/resources/help/blocksize.pdhelp
+++ b/resources/help/blocksize.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 713 178 317 270 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 228 See also:;
 #X obj 36 180 print;

--- a/resources/help/block~.pdhelp
+++ b/resources/help/block~.pdhelp
@@ -5,7 +5,7 @@
 #X restore 84 300 pd;
 #X text 12 300 See also:;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 block~;
 #X text 12 96 In addition \, switch~ can locally turn DSP on and off.;
 #X f 53;

--- a/resources/help/bng.pdhelp
+++ b/resources/help/bng.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 793 100 302 318 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj 36 276 print;
 #X msg 36 132 -3.14;
 #N canvas 804 197 456 378 edit 0;

--- a/resources/help/bp~.pdhelp
+++ b/resources/help/bp~.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 685 100 321 389 12;
 #X obj 84 348 vcf~;
 #X text 12 348 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 bp~;
 #X obj 180 348 lop~;

--- a/resources/help/change.pdhelp
+++ b/resources/help/change.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 680 112 300 303 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 change;
 #X text 12 264 See also:;

--- a/resources/help/closebang.pdhelp
+++ b/resources/help/closebang.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 787 164 276 256 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X obj 36 180 print;
 #X text 12 216 See also:;

--- a/resources/help/cnv.pdhelp
+++ b/resources/help/cnv.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 814 256 301 186 12;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 cnv;
 #N canvas 830 239 454 291 edit 0;
 #X obj 36 168 s \$0-iem;

--- a/resources/help/comment.pdhelp
+++ b/resources/help/comment.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 712 215 363 107 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 comment;
 #X text 12 72 To avoid artefacts quote numbers (e.g. '3.14').;

--- a/resources/help/constructor.pdhelp
+++ b/resources/help/constructor.pdhelp
@@ -3,7 +3,7 @@
 #X obj 180 276 set;
 #X obj 180 156 pointer;
 #X obj 84 276 struct;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 12 276 See also:;
 #X obj -60 12 freeze;
 #N canvas 367 201 335 326 \$0-data 1;

--- a/resources/help/cos~.pdhelp
+++ b/resources/help/cos~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 144 cos~;
 #X obj 84 300 osc~;
 #X obj 132 300 tabread4~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 cos~;
 #N canvas 892 150 378 503 more 0;

--- a/resources/help/counter.pdhelp
+++ b/resources/help/counter.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 720 133 275 248 12;
 #X text 12 216 See also:;
 #X obj 84 216 select;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 counter;
 #X obj 144 216 uzi;

--- a/resources/help/cpole~.pdhelp
+++ b/resources/help/cpole~.pdhelp
@@ -3,7 +3,7 @@
 #X obj 84 288 lop~;
 #X obj 132 288 rpole~;
 #X obj 192 288 czero~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 cpole~;
 #X text 12 72 Complex One-Pole filter.;

--- a/resources/help/ctlin.pdhelp
+++ b/resources/help/ctlin.pdhelp
@@ -5,7 +5,7 @@
 #X obj 132 240 bendin;
 #X obj 192 240 touchin;
 #X text 12 240 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 ctlin;
 #X text 12 72 Report MIDI control change.;

--- a/resources/help/ctlout.pdhelp
+++ b/resources/help/ctlout.pdhelp
@@ -3,7 +3,7 @@
 #X obj 180 216 bendin;
 #X obj 240 216 touchin;
 #X text 12 216 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 72 Output MIDI control change.;
 #X obj 36 180 ctlout;

--- a/resources/help/czero_rev~.pdhelp
+++ b/resources/help/czero_rev~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 480 84 669 328 12;
 #X obj 84 288 czero~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 czero_rev~;
 #X text 12 72 Complex "reverse" One-Zero filter.;

--- a/resources/help/czero~.pdhelp
+++ b/resources/help/czero~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 84 288 rzero~;
 #X obj 144 288 cpole~;
 #X obj 36 108 czero~ 0.9 0.4;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 czero~;
 #X text 12 72 Complex One-Zero filter.;

--- a/resources/help/delay.pdhelp
+++ b/resources/help/delay.pdhelp
@@ -3,7 +3,7 @@
 #X obj 180 276 timer;
 #X obj 132 276 metro;
 #X msg 60 108 2000;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 delay;
 #X text 12 276 See also:;

--- a/resources/help/delread~.pdhelp
+++ b/resources/help/delread~.pdhelp
@@ -3,7 +3,7 @@
 #X obj 84 228 delwrite~;
 #X obj 168 228 delread4~;
 #X f 9;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 delread~;
 #X text 12 72 Read a signal from a delay line.;

--- a/resources/help/delwrite~.pdhelp
+++ b/resources/help/delwrite~.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 708 199 322 231 12;
 #X obj 84 192 delread~;
 #X obj 156 192 delread4~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 delwrite~;
 #X text 12 72 Writes a signal in a delay line.;

--- a/resources/help/draw.pdhelp
+++ b/resources/help/draw.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 599 314 301 267 12;
 #X obj 84 228 struct;
 #X text 12 228 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 draw;
 #X text 12 72 Draw the fields of a scalar.;

--- a/resources/help/drawcircle.pdhelp
+++ b/resources/help/drawcircle.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 859 298 301 279 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #N canvas 477 234 347 296 \$0-data 1;
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 36 108 pd \$0-data;

--- a/resources/help/drawpolygon.pdhelp
+++ b/resources/help/drawpolygon.pdhelp
@@ -20,7 +20,7 @@
 #X obj 36 120 draw polygon -color 800;
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 288 108 pd more;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #N canvas 37 192 384 178 \$0-data 0;
 #X coords 0 0 1 1 230 140 1 0 0;

--- a/resources/help/drawtext.pdhelp
+++ b/resources/help/drawtext.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 580 154 406 267 12;
 #X obj 84 228 struct;
 #X text 12 228 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #N canvas 680 376 324 223 \$0-data 0;
 #X coords 0 0 1 1 125 100 1 0 0;

--- a/resources/help/dspstatus.pdhelp
+++ b/resources/help/dspstatus.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 591 209 300 233 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 192 See also:;
 #X text 24 24 dspstatus;

--- a/resources/help/element.pdhelp
+++ b/resources/help/element.pdhelp
@@ -6,7 +6,7 @@
 #X floatatom 36 108 5 0 0 0 - - -;
 #X f 5;
 #X obj 264 324 struct;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 72 Fetch a pointer to an element of an array.;
 #N canvas 622 206 307 251 more 0;

--- a/resources/help/env~.pdhelp
+++ b/resources/help/env~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 808 161 300 325 12;
 #X obj 36 180 *~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 env~;
 #X text 12 72 Envelope follower.;

--- a/resources/help/expr.pdhelp
+++ b/resources/help/expr.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 515 168 510 413 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 expr;
 #X floatatom 180 108 0 0 0 0 - - -;
 #X obj 36 144 expr 2 + 3;

--- a/resources/help/fft~.pdhelp
+++ b/resources/help/fft~.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 640 106 588 574 12;
 #X obj 84 696 ifft~;
 #X obj 180 696 rifft~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 12 696 See also:;
 #X obj -60 12 freeze;
 #X obj 36 108 tabreceive~ \$0-impulse;

--- a/resources/help/fields.pdhelp
+++ b/resources/help/fields.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 764 238 376 317 12;
 #X obj 120 276 getsize;
 #X obj 36 168 pointer;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 276 See also:;
 #N canvas 328 198 375 337 \$0-data 1;

--- a/resources/help/float.pdhelp
+++ b/resources/help/float.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 801 194 300 305 12;
 #X obj 36 180 float 6.5;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 float;
 #N canvas 939 363 311 212 more 0;

--- a/resources/help/framp~.pdhelp
+++ b/resources/help/framp~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 228 rfft~;
 #X obj 36 264 framp~;
 #X obj 36 192 osc~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 framp~;
 #X obj 84 552 fft~;

--- a/resources/help/freeze.pdhelp
+++ b/resources/help/freeze.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 637 173 410 147 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 freeze;
 #X text 12 72 Make a patch unchangeable (editable but not savable).;
 #X obj 36 108 freeze;

--- a/resources/help/garray.pdhelp
+++ b/resources/help/garray.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 753 129 534 350 12;
 #X obj 84 312 array;
 #X text 12 312 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 garray;
 #X obj 132 312 tabread;

--- a/resources/help/gatom.pdhelp
+++ b/resources/help/gatom.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 841 125 343 294 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 gatom;
 #X obj 144 192 s \$0-to;

--- a/resources/help/get.pdhelp
+++ b/resources/help/get.pdhelp
@@ -2,7 +2,7 @@
 #X obj 84 240 set;
 #X msg 36 132 next;
 #X obj 36 168 pointer;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 get;
 #X text 12 240 See also:;

--- a/resources/help/getsize.pdhelp
+++ b/resources/help/getsize.pdhelp
@@ -2,7 +2,7 @@
 #X obj 84 264 setsize;
 #X obj 36 144 pointer;
 #X obj 144 264 element;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 getsize;
 #X text 12 72 Get the number of elements of an array.;

--- a/resources/help/hip~.pdhelp
+++ b/resources/help/hip~.pdhelp
@@ -3,7 +3,7 @@
 #X floatatom 36 264 0 0 0 0 - - -;
 #X obj 36 204 hip~ 5;
 #X obj 36 108 osc~ 100;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 hip~;
 #X text 12 312 See also:;

--- a/resources/help/ifft~.pdhelp
+++ b/resources/help/ifft~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 566 102 536 603 12;
 #X obj 36 324 /~ 64;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 564 See also:;
 #X obj 36 156 tabreceive~ \$0-impulse;

--- a/resources/help/int.pdhelp
+++ b/resources/help/int.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 649 222 300 300 12;
 #X obj 36 192 int 6;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 int;
 #X floatatom 60 108 5 0 0 1 - - -;

--- a/resources/help/key.pdhelp
+++ b/resources/help/key.pdhelp
@@ -4,7 +4,7 @@
 #X obj 180 108 keyname;
 #X symbolatom 252 144 10 0 0 0 - - -;
 #X f 10;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 key;
 #X text 12 288 See also:;

--- a/resources/help/line.pdhelp
+++ b/resources/help/line.pdhelp
@@ -4,7 +4,7 @@
 #X obj 84 264 line~;
 #X obj 132 264 vline~;
 #X text 12 264 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 line;
 #X text 12 72 Ramp generator.;

--- a/resources/help/line~.pdhelp
+++ b/resources/help/line~.pdhelp
@@ -6,7 +6,7 @@
 #X msg 108 108 0 5000;
 #X obj 156 276 line;
 #X obj 96 276 vline~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 line~;
 #X text 12 72 Audio ramp generator.;

--- a/resources/help/list.pdhelp
+++ b/resources/help/list.pdhelp
@@ -164,7 +164,7 @@
 #X connect 7 0 0 0;
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 36 588 pd from/to;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 list;
 #X text 12 624 See also:;

--- a/resources/help/loadbang.pdhelp
+++ b/resources/help/loadbang.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 729 136 300 254 12;
 #X obj 36 108 loadbang;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 loadbang;
 #X msg 36 144 Hello!;

--- a/resources/help/logical.pdhelp
+++ b/resources/help/logical.pdhelp
@@ -3,7 +3,7 @@
 #X obj 144 204 >=;
 #X obj 72 204 <=;
 #X obj 36 204 <;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 logical;
 #X text 12 276 See also:;

--- a/resources/help/logical~.pdhelp
+++ b/resources/help/logical~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 108 osc~ 440;
 #X obj 156 108 osc~ 675;
 #X obj 156 492 min~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 492 See also:;
 #X obj 252 492 wrap~;

--- a/resources/help/lop~.pdhelp
+++ b/resources/help/lop~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 84 300 hip~;
 #X obj 132 300 bp~;
 #X obj 168 300 vcf~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 lop~;
 #X text 12 300 See also:;

--- a/resources/help/lrshift~.pdhelp
+++ b/resources/help/lrshift~.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 585 117 552 452 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 lrshift~;
 #X text 12 72 Shift signal vector samples left or right.;

--- a/resources/help/mag~.pdhelp
+++ b/resources/help/mag~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 132 324 fft~;
 #X obj 228 324 ifft~;
 #X obj 276 324 rifft~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 12 324 See also:;
 #X obj -60 12 freeze;
 #X text 24 24 mag~;

--- a/resources/help/makefilename.pdhelp
+++ b/resources/help/makefilename.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 180 print;
 #X obj 36 312 print;
 #X obj 36 276 makefilename dog%s.aif;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 makefilename;
 #N canvas 566 184 300 247 more 0;

--- a/resources/help/makenote.pdhelp
+++ b/resources/help/makenote.pdhelp
@@ -2,7 +2,7 @@
 #X msg 36 108 60;
 #X obj 84 264 stripnote;
 #X text 12 264 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 makenote;
 #X obj 36 192 pack;

--- a/resources/help/math.pdhelp
+++ b/resources/help/math.pdhelp
@@ -3,7 +3,7 @@
 #X obj 84 264 expr;
 #X obj 132 264 &&;
 #X obj 168 264 ||;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 math;
 #X text 12 72 Mathematical functions.;

--- a/resources/help/math~.pdhelp
+++ b/resources/help/math~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 608 120 431 267 12;
 #X text 12 228 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 72 Mathematical functions.;
 #N canvas 854 133 395 438 transcendental 0;

--- a/resources/help/menubutton.pdhelp
+++ b/resources/help/menubutton.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 757 272 300 345 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj 36 300 print;
 #N canvas 900 171 300 452 edit 0;
 #X msg 36 48 initialize 1;

--- a/resources/help/message.pdhelp
+++ b/resources/help/message.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 542 86 446 281 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 message;
 #X obj 36 192 print;

--- a/resources/help/metro.pdhelp
+++ b/resources/help/metro.pdhelp
@@ -6,7 +6,7 @@
 #X obj 132 324 pipe;
 #X text 12 324 See also:;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 metro;
 #N canvas 923 261 348 191 more 0;
 #X obj 36 24 tgl 15 0 empty empty empty 17 7 0 10 #ffffff #000000 #000000 0 1;

--- a/resources/help/mica.pdhelp
+++ b/resources/help/mica.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 653 79 490 655 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 336 Examples.;
 #X obj 36 108 mica set;

--- a/resources/help/midiin.pdhelp
+++ b/resources/help/midiin.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 799 123 275 277 12;
 #X obj 36 108 midiin;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 midiin;
 #X text 12 240 See also:;

--- a/resources/help/midiout.pdhelp
+++ b/resources/help/midiout.pdhelp
@@ -3,7 +3,7 @@
 #X obj 204 204 pgmout;
 #X obj 144 204 ctlout;
 #X obj 36 156 midiout;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 midiout;
 #X text 12 204 See also:;

--- a/resources/help/midirealtimein.pdhelp
+++ b/resources/help/midirealtimein.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 855 112 275 256 12;
 #X obj 84 216 midiin;
 #X text 12 216 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X obj 36 180 print byte;
 #X obj 144 180 print port;

--- a/resources/help/moses.pdhelp
+++ b/resources/help/moses.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 803 191 275 265 12;
 #X obj 36 144 moses 10;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 moses;
 #X obj 84 228 spigot;

--- a/resources/help/namecanvas.pdhelp
+++ b/resources/help/namecanvas.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 708 122 275 252 12;
 #X obj 132 180 namecanvas bonzo;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 namecanvas;
 #X obj -60 12 freeze;
 #X obj 132 108 loadbang;

--- a/resources/help/nbx.pdhelp
+++ b/resources/help/nbx.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 740 170 302 321 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 nbx;
 #X text 60 24 dial;
 #X obj -60 12 freeze;

--- a/resources/help/netreceive.pdhelp
+++ b/resources/help/netreceive.pdhelp
@@ -26,7 +26,7 @@
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 204 180 pd more;
 #X text 12 252 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 netreceive;
 #X obj -60 12 freeze;
 #X floatatom 132 216 5 0 0 1 - - -;

--- a/resources/help/netsend.pdhelp
+++ b/resources/help/netsend.pdhelp
@@ -6,7 +6,7 @@
 #X msg 36 132 disconnect;
 #X obj 96 312 netreceive;
 #X text 12 312 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 netsend;
 #N canvas 440 177 552 489 more 0;

--- a/resources/help/noise~.pdhelp
+++ b/resources/help/noise~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 539 235 498 283 12;
 #X obj 36 108 noise~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 noise~;
 #N canvas 0 22 500 350 \$0-array 0;

--- a/resources/help/notein.pdhelp
+++ b/resources/help/notein.pdhelp
@@ -4,7 +4,7 @@
 #X obj 84 216 ctlin;
 #X obj 132 216 pgmin;
 #X obj 180 216 bendin;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 notein;
 #X text 12 216 See also:;

--- a/resources/help/noteout.pdhelp
+++ b/resources/help/noteout.pdhelp
@@ -4,7 +4,7 @@
 #X msg 36 108 60;
 #X obj 144 240 pgmout;
 #X obj 84 240 ctlout;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 noteout;
 #X text 12 72 Ouptut MIDI notes.;

--- a/resources/help/openpanel.pdhelp
+++ b/resources/help/openpanel.pdhelp
@@ -3,7 +3,7 @@
 #X obj 36 228 print;
 #X obj 96 264 savepanel;
 #X text 12 264 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 openpanel;
 #X msg 72 108 /Users;

--- a/resources/help/oscbundle.pdhelp
+++ b/resources/help/oscbundle.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 503 187 365 388 12;
 #X obj 168 348 oscparse;
 #X text 12 348 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 oscbundle;
 #X obj 84 348 oscformat;

--- a/resources/help/oscformat.pdhelp
+++ b/resources/help/oscformat.pdhelp
@@ -2,7 +2,7 @@
 #X msg 36 108 4 5 weasel 6 7 rat;
 #X obj 168 228 oscparse;
 #X text 12 228 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 oscformat;
 #X text 12 72 Convert message to OSC packets.;

--- a/resources/help/oscparse.pdhelp
+++ b/resources/help/oscparse.pdhelp
@@ -3,7 +3,7 @@
 #X obj 168 264 oscformat;
 #X text 12 264 See also:;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 12 72 Parse OSC packets into messages.;
 #X f 33;
 #X text 24 24 oscparse;

--- a/resources/help/oscstream.pdhelp
+++ b/resources/help/oscstream.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 556 191 389 377 12;
 #X text 12 336 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X obj 84 336 oscformat;
 #X obj 36 132 oscformat menu;

--- a/resources/help/osc~.pdhelp
+++ b/resources/help/osc~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 144 276 cos~;
 #X obj 192 276 tabread4~;
 #X obj 84 276 phasor~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 osc~;
 #X obj -60 12 freeze;
 #X text 12 72 Cosine wave oscillator.;

--- a/resources/help/pack.pdhelp
+++ b/resources/help/pack.pdhelp
@@ -5,7 +5,7 @@
 #X obj 84 324 unpack;
 #X msg 96 108 1 2 dog;
 #X obj 144 324 trigger;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 pack;
 #X floatatom 36 108 5 0 0 1 - - -;

--- a/resources/help/pd.pdhelp
+++ b/resources/help/pd.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 565 220 300 243 12;
 #X obj 84 204 block~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 pd;
 #X text 12 204 See also:;

--- a/resources/help/pgmin.pdhelp
+++ b/resources/help/pgmin.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 108 pgmin;
 #X obj 84 216 midiin;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 pgmin;
 #X text 12 216 See also:;
 #X obj 84 144 print channel;

--- a/resources/help/pgmout.pdhelp
+++ b/resources/help/pgmout.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 604 150 482 266 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 pgmout;
 #X text 12 228 See also:;

--- a/resources/help/phasor~.pdhelp
+++ b/resources/help/phasor~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 84 288 osc~;
 #X obj 132 288 cos~;
 #X obj 180 288 tabread4~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 phasor~;
 #X text 12 72 Sawtooth generator.;

--- a/resources/help/pipe.pdhelp
+++ b/resources/help/pipe.pdhelp
@@ -1,11 +1,11 @@
-#N canvas 571 196 315 337 12;
+#N canvas 571 196 300 338 12;
 #X obj 36 228 pipe 2000;
 #X msg 96 108 flush;
 #X msg 156 108 clear;
 #X obj 84 300 delay;
 #X obj 180 300 timer;
 #X text 12 300 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 pipe;
 #N canvas 793 133 355 520 more 0;
@@ -54,7 +54,7 @@
 #X connect 18 0 6 0;
 #X connect 19 0 18 0;
 #X coords 0 0 1 1 250 175 0 0 0;
-#X restore 228 180 pd more;
+#X restore 204 180 pd more;
 #X obj 36 264 print;
 #X floatatom 36 108 5 0 0 1 - - -;
 #X f 5;
@@ -117,7 +117,7 @@
 #X connect 24 0 3 0;
 #X connect 25 0 1 0;
 #X coords 0 0 1 1 250 175 0 0 0;
-#X restore 228 228 pd units;
+#X restore 204 228 pd units;
 #N canvas 723 213 300 317 again 0;
 #X obj 36 156 print;
 #X floatatom 36 48 5 0 0 1 - - -;
@@ -135,7 +135,7 @@
 #X connect 4 0 5 0;
 #X connect 6 0 4 0;
 #X coords 0 0 1 1 250 175 0 0 0;
-#X restore 228 204 pd again;
+#X restore 204 204 pd again;
 #X connect 0 0 10 0;
 #X connect 1 0 0 0;
 #X connect 2 0 0 0;

--- a/resources/help/plot.pdhelp
+++ b/resources/help/plot.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 876 271 300 278 12;
 #X text 12 240 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #N canvas 784 105 367 646 more 0;
 #X text 12 12 Name of the array to draw.;

--- a/resources/help/pointer.pdhelp
+++ b/resources/help/pointer.pdhelp
@@ -4,7 +4,7 @@
 #X obj 84 372 append;
 #X obj 36 180 pointer;
 #X msg 36 132 next;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 pointer;
 #X text 12 372 See also:;

--- a/resources/help/poly.pdhelp
+++ b/resources/help/poly.pdhelp
@@ -8,7 +8,7 @@
 #X obj 36 252 pack 0 0 0;
 #X f 10;
 #X obj 60 288 print;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 poly;
 #X text 12 72 Polyphonic voice allocator.;

--- a/resources/help/prepend.pdhelp
+++ b/resources/help/prepend.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 757 190 300 359 12;
 #X obj 36 288 print;
 #X msg 36 180 1 2 dog;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X obj 36 108 bng 15 250 50 0 empty empty empty 17 7 0 10 #ffffff #000000 #000000;
 #X floatatom 36 132 5 0 0 1 - - -;

--- a/resources/help/print.pdhelp
+++ b/resources/help/print.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 692 134 300 277 12;
 #X msg 36 156 walk the dog;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 print;
 #X obj 36 204 print;

--- a/resources/help/print~.pdhelp
+++ b/resources/help/print~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 861 131 275 278 12;
 #X obj 36 204 print~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 print~;
 #X text 12 240 See also:;

--- a/resources/help/qlist.pdhelp
+++ b/resources/help/qlist.pdhelp
@@ -5,7 +5,7 @@
 #X obj 84 312 textfile;
 #X text 12 312 See also:;
 #X obj 156 312 text;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 qlist;
 #X text 12 72 Text-based sequencer.;

--- a/resources/help/radio.pdhelp
+++ b/resources/help/radio.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 665 81 462 320 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 vradio;
 #X text 84 24 hradio;

--- a/resources/help/random.pdhelp
+++ b/resources/help/random.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 774 98 300 312 12;
 #X obj 36 204 random 5;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 random;
 #X obj -60 12 freeze;
 #X obj 36 108 bng 15 250 50 0 empty empty empty 17 7 0 10 #ffffff #000000 #000000;

--- a/resources/help/readsf~.pdhelp
+++ b/resources/help/readsf~.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 784 107 452 386 12;
 #X obj 84 348 soundfiler;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 readsf~;
 #X obj 168 348 writesf~;
 #X obj 240 348 tabplay~;

--- a/resources/help/realtime.pdhelp
+++ b/resources/help/realtime.pdhelp
@@ -3,7 +3,7 @@
 #X obj 36 168 realtime;
 #X obj 84 240 timer;
 #X text 12 240 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 realtime;
 #X obj 36 108 bng 15 250 50 0 empty empty empty 0 0 0 10 #ffffff #000000 #000000;

--- a/resources/help/receive.pdhelp
+++ b/resources/help/receive.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 677 143 379 311 12;
 #X obj 84 276 send;
 #X text 12 276 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X obj 132 276 receive~;
 #X floatatom 36 108 5 0 0 0 - - -;

--- a/resources/help/rfft~.pdhelp
+++ b/resources/help/rfft~.pdhelp
@@ -3,7 +3,7 @@
 #X obj 192 516 ifft~;
 #X obj 84 516 rifft~;
 #X obj 36 144 rfft~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 12 516 See also:;
 #X text 24 24 rfft~;
 #X obj -60 12 freeze;

--- a/resources/help/rifft~.pdhelp
+++ b/resources/help/rifft~.pdhelp
@@ -4,7 +4,7 @@
 #X obj 84 564 rfft~;
 #X obj 36 252 rifft~;
 #X obj 36 324 /~ 64;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 rifft~;
 #X text 12 564 See also:;

--- a/resources/help/rmag~.pdhelp
+++ b/resources/help/rmag~.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 813 114 300 335 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 12 300 See also:;
 #X obj -60 12 freeze;
 #X floatatom 36 108 5 0 0 1 - - -;

--- a/resources/help/route.pdhelp
+++ b/resources/help/route.pdhelp
@@ -11,7 +11,7 @@
 #X obj 264 384 pack;
 #X obj 312 384 unpack;
 #X obj 204 384 spigot;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 route;
 #X obj -60 12 freeze;
 #N canvas 765 129 366 486 more 0;

--- a/resources/help/rpole~.pdhelp
+++ b/resources/help/rpole~.pdhelp
@@ -4,7 +4,7 @@
 #X obj 132 288 cpole~;
 #X obj 36 108 rpole~ 0.9;
 #X text 12 168 y[n] = x[n] + a[n] * y[n-1];
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 rpole~;
 #X text 12 72 Real One-Pole filter.;

--- a/resources/help/rzero_rev~.pdhelp
+++ b/resources/help/rzero_rev~.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 636 95 669 327 12;
 #X obj 84 288 rzero~;
 #X obj 36 108 rzero_rev~ 1;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 rzero_rev~;
 #X text 12 144 It calculates the following difference equation:;

--- a/resources/help/rzero~.pdhelp
+++ b/resources/help/rzero~.pdhelp
@@ -3,7 +3,7 @@
 #X obj 204 288 rzero_rev~;
 #X obj 84 288 czero~;
 #X obj 36 108 rzero~ 1;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 rzero~;
 #X text 12 288 See also:;

--- a/resources/help/samphold~.pdhelp
+++ b/resources/help/samphold~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 777 122 504 363 12;
 #X obj 36 204 samphold~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 samphold~;
 #X text 12 72 Sample and hold unit.;

--- a/resources/help/samplerate.pdhelp
+++ b/resources/help/samplerate.pdhelp
@@ -16,7 +16,7 @@
 #X connect 2 0 1 0;
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 168 144 pd more;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 216 See also:;
 #X text 12 72 Get the audio sample rate.;

--- a/resources/help/savepanel.pdhelp
+++ b/resources/help/savepanel.pdhelp
@@ -3,7 +3,7 @@
 #X obj 36 144 savepanel;
 #X obj 84 240 openpanel;
 #X text 12 240 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 savepanel;
 #X obj 36 108 bng 15 250 50 0 empty empty empty 17 7 0 10 #ffffff #000000 #000000;

--- a/resources/help/scalar.pdhelp
+++ b/resources/help/scalar.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 513 231 438 361 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 scalar;
 #X text 12 324 See also:;

--- a/resources/help/scalars.pdhelp
+++ b/resources/help/scalars.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 501 187 412 282 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #N canvas 179 292 300 236 \$0-data 1;
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 36 108 pd \$0-data;

--- a/resources/help/select.pdhelp
+++ b/resources/help/select.pdhelp
@@ -6,7 +6,7 @@
 #X obj 84 348 route;
 #X text 12 348 See also:;
 #X obj 132 348 trigger;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 select;
 #X obj -60 12 freeze;
 #N canvas 798 214 369 419 more 0;

--- a/resources/help/send.pdhelp
+++ b/resources/help/send.pdhelp
@@ -13,7 +13,7 @@
 #X f 5;
 #X obj 84 384 receive;
 #X text 12 384 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 send;
 #X obj -60 12 freeze;
 #X obj 36 144 s ratatouille;

--- a/resources/help/send~.pdhelp
+++ b/resources/help/send~.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 694 172 365 337 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 send~;
 #X obj 84 300 throw~;

--- a/resources/help/set.pdhelp
+++ b/resources/help/set.pdhelp
@@ -6,7 +6,7 @@
 #X f 5;
 #X obj 192 192 pointer;
 #X obj 96 276 get;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 set;
 #X text 12 276 See also:;

--- a/resources/help/setsize.pdhelp
+++ b/resources/help/setsize.pdhelp
@@ -5,7 +5,7 @@
 #X f 5;
 #X obj 204 384 element;
 #X obj 264 384 struct;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 setsize;
 #X obj -60 12 freeze;
 #X obj 84 384 getsize;

--- a/resources/help/sig~.pdhelp
+++ b/resources/help/sig~.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 821 152 300 275 12;
 #X obj 36 132 sig~;
 #X obj 36 180 snapshot~ 0;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 sig~;
 #X text 12 72 Convert numbers to audio signal.;

--- a/resources/help/slider.pdhelp
+++ b/resources/help/slider.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 802 196 339 381 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #N canvas 843 251 456 379 edit 0;
 #X msg 36 48 initialize 1;

--- a/resources/help/snapshot~.pdhelp
+++ b/resources/help/snapshot~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 228 snapshot~;
 #X text 12 300 See also:;
 #X obj 84 300 print~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 snapshot~;
 #N canvas 897 103 300 416 more 0;

--- a/resources/help/soundfiler.pdhelp
+++ b/resources/help/soundfiler.pdhelp
@@ -3,7 +3,7 @@
 #X obj 84 336 tabplay~;
 #X obj 216 336 writesf~;
 #X obj 156 336 readsf~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 soundfiler;
 #X text 12 72 Read and write soundfiles from and to arrays.;

--- a/resources/help/spigot.pdhelp
+++ b/resources/help/spigot.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 584 228 415 339 12;
 #X obj 36 264 print;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 spigot;
 #X obj 96 192 tgl 15 0 empty empty empty 17 7 0 10 #ffffff #000000 #000000 0 1;

--- a/resources/help/stripnote.pdhelp
+++ b/resources/help/stripnote.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 180 stripnote;
 #X obj 84 276 makenote;
 #X text 12 276 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 stripnote;
 #X text 12 72 Takes note-off out of a stream of MIDI notes.;

--- a/resources/help/struct.pdhelp
+++ b/resources/help/struct.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 497 295 391 292 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 struct;
 #X text 12 252 See also:;

--- a/resources/help/swap.pdhelp
+++ b/resources/help/swap.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 888 165 300 298 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 swap;
 #X text 12 264 See also:;

--- a/resources/help/symbol.pdhelp
+++ b/resources/help/symbol.pdhelp
@@ -5,7 +5,7 @@
 #X obj 84 276 int;
 #X obj 120 276 float;
 #X obj 36 108 bng 15 250 50 0 empty empty empty 17 7 0 10 #ffffff #000000 #000000;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 symbol;
 #X msg 36 156 zorkons;

--- a/resources/help/sysexin.pdhelp
+++ b/resources/help/sysexin.pdhelp
@@ -1,7 +1,7 @@
 #N canvas 959 168 300 257 12;
 #X obj 84 216 midiin;
 #X text 12 216 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 sysexin;
 #X text 12 72 Report MIDI system exclusive.;

--- a/resources/help/tabosc4~.pdhelp
+++ b/resources/help/tabosc4~.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 611 122 508 568 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabosc4~;
 #X text 12 72 4-point interpolating oscillator.;

--- a/resources/help/tabplay~.pdhelp
+++ b/resources/help/tabplay~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 84 516 soundfiler;
 #X obj 240 516 tabread4~;
 #X msg 72 108 stop;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabplay~;
 #X text 12 516 See also:;

--- a/resources/help/tabread.pdhelp
+++ b/resources/help/tabread.pdhelp
@@ -9,7 +9,7 @@
 #X obj 240 300 tabread~;
 #X obj 384 300 array;
 #X text 12 300 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabread;
 #X text 12 72 Read numbers from an array.;

--- a/resources/help/tabread4.pdhelp
+++ b/resources/help/tabread4.pdhelp
@@ -5,7 +5,7 @@
 #X coords 0 10 9 0 250 200 1 0 0;
 #X restore 192 120 graph \$0-array;
 #X obj 84 324 tabread;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabread4;
 #X text 12 324 See also:;

--- a/resources/help/tabread4~.pdhelp
+++ b/resources/help/tabread4~.pdhelp
@@ -8,7 +8,7 @@
 #X floatatom 36 276 0 0 0 0 - - -;
 #X obj 228 384 tabwrite~;
 #X obj 312 384 tabplay~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabread4~;
 #N canvas 536 343 470 288 more 0;

--- a/resources/help/tabread~.pdhelp
+++ b/resources/help/tabread~.pdhelp
@@ -8,7 +8,7 @@
 #X obj 168 336 tabwrite~;
 #X obj 252 336 tabread;
 #X obj 84 336 tabread4~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabread~;
 #X text 12 336 See also:;

--- a/resources/help/tabreceive.pdhelp
+++ b/resources/help/tabreceive.pdhelp
@@ -9,7 +9,7 @@
 #X obj 156 300 tabread~;
 #X obj 300 300 array;
 #X text 12 300 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #N canvas 759 358 453 260 more 0;
 #X obj 36 216 print;

--- a/resources/help/tabreceive~.pdhelp
+++ b/resources/help/tabreceive~.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 728 136 489 337 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabreceive~;
 #X text 12 300 See also:;

--- a/resources/help/tabsend~.pdhelp
+++ b/resources/help/tabsend~.pdhelp
@@ -1,6 +1,6 @@
 #N canvas 632 150 462 350 12;
 #X obj -60 12 freeze;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 tabsend~;
 #X text 12 72 Writes one block of a signal continuously to an array.;
 #X obj 84 312 tabreceive~;

--- a/resources/help/tabwrite.pdhelp
+++ b/resources/help/tabwrite.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 575 160 497 314 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X obj 132 276 tabwrite~;
 #X text 12 276 See also:;

--- a/resources/help/tabwrite~.pdhelp
+++ b/resources/help/tabwrite~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 204 276 tabread;
 #X obj 84 276 tabwrite;
 #X obj 264 276 tabread4~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 tabwrite~;
 #X text 12 72 Write a signal in an array.;

--- a/resources/help/text.pdhelp
+++ b/resources/help/text.pdhelp
@@ -288,7 +288,7 @@
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 36 492 pd sequence;
 #X text 12 540 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 text;
 #X text 12 72 The first argument sets its function.;

--- a/resources/help/textfile.pdhelp
+++ b/resources/help/textfile.pdhelp
@@ -3,7 +3,7 @@
 #X obj 36 228 textfile;
 #X msg 96 180 read textfile.txt;
 #X obj 84 324 qlist;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 textfile;
 #X text 12 324 See also:;

--- a/resources/help/tgl.pdhelp
+++ b/resources/help/tgl.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 807 138 300 295 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 tgl;
 #X obj -60 12 freeze;
 #X obj 36 216 tgl 15 0 \$0-from \$0-to empty 17 7 0 10 #ffffff #000000 #000000 1234 1234;

--- a/resources/help/threshold~.pdhelp
+++ b/resources/help/threshold~.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 764 142 305 410 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 threshold~;
 #X text 12 72 Trigger from audio signal.;

--- a/resources/help/throw~.pdhelp
+++ b/resources/help/throw~.pdhelp
@@ -2,7 +2,7 @@
 #X text 12 252 See also:;
 #X obj 84 252 send~;
 #X obj 132 252 receive~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 throw~;
 #N canvas 779 127 446 391 more 0;

--- a/resources/help/timer.pdhelp
+++ b/resources/help/timer.pdhelp
@@ -3,7 +3,7 @@
 #X obj 204 240 delay;
 #X obj 156 240 metro;
 #X text 12 240 See also:;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 timer;
 #X obj 84 240 realtime;

--- a/resources/help/title.pdhelp
+++ b/resources/help/title.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 764 172 277 258 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 12 216 See also:;
 #X obj 84 216 samplerate;

--- a/resources/help/trigger.pdhelp
+++ b/resources/help/trigger.pdhelp
@@ -3,7 +3,7 @@
 #X obj 84 252 pack;
 #X obj 132 252 unpack;
 #X obj 192 252 select;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 trigger;
 #N canvas 539 459 327 200 again 0;

--- a/resources/help/unpack.pdhelp
+++ b/resources/help/unpack.pdhelp
@@ -2,7 +2,7 @@
 #X obj 84 276 pack;
 #X msg 36 108 1 2;
 #X msg 36 132 3 4 shut;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X text 24 24 unpack;
 #X obj -60 12 freeze;
 #X obj 132 276 trigger;

--- a/resources/help/until.pdhelp
+++ b/resources/help/until.pdhelp
@@ -5,7 +5,7 @@
 #X obj 120 168 + 1;
 #X obj 36 240 print;
 #X obj 120 192 mod 10;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 until;
 #X text 12 276 See also:;

--- a/resources/help/uzi.pdhelp
+++ b/resources/help/uzi.pdhelp
@@ -1,5 +1,5 @@
 #N canvas 907 99 274 326 12;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -72 12 freeze;
 #X text 24 24 uzi;
 #X text 12 288 See also:;

--- a/resources/help/value.pdhelp
+++ b/resources/help/value.pdhelp
@@ -7,7 +7,7 @@
 #X f 5;
 #X floatatom 192 216 5 0 0 0 - - -;
 #X f 5;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 value;
 #X text 12 72 Shared value (named variable).;

--- a/resources/help/vcf~.pdhelp
+++ b/resources/help/vcf~.pdhelp
@@ -3,7 +3,7 @@
 #X floatatom 36 372 0 0 0 0 - - -;
 #X obj 84 408 bp~;
 #X floatatom 120 312 0 0 0 0 - - -;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 vcf~;
 #X text 12 408 See also:;

--- a/resources/help/vd~.pdhelp
+++ b/resources/help/vd~.pdhelp
@@ -2,7 +2,7 @@
 #X obj 36 144 sig~;
 #X obj 84 216 delwrite~;
 #X obj 168 216 delread~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 vd~;
 #X text 12 216 See also:;

--- a/resources/help/vline~.pdhelp
+++ b/resources/help/vline~.pdhelp
@@ -5,7 +5,7 @@
 #X obj 132 300 line~;
 #X obj 36 192 vline~;
 #X msg 36 132 0 1000;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 vline~;
 #X text 12 300 See also:;

--- a/resources/help/vu.pdhelp
+++ b/resources/help/vu.pdhelp
@@ -13,7 +13,7 @@
 #X connect 4 0 0 0;
 #X coords 0 0 1 1 250 175 0 0 0;
 #X restore 132 252 pd edit;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj 36 156 vu 15 120 \$0-to empty 17 7 0 10 #ffffff #000000 0 0;
 #X text 24 24 vu;
 #X obj -60 12 freeze;

--- a/resources/help/writesf~.pdhelp
+++ b/resources/help/writesf~.pdhelp
@@ -3,7 +3,7 @@
 #X obj 84 348 soundfiler;
 #X obj 84 264 osc~ 440;
 #X obj 168 348 readsf~;
-#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #cccccc #000000;
+#X obj 12 12 cnv 15 275 45 empty empty empty 0 -7 0 10 #ffd300 #000000;
 #X obj -60 12 freeze;
 #X text 24 24 writesf~;
 #X text 12 348 See also:;

--- a/tcl/ui_global.tcl
+++ b/tcl/ui_global.tcl
@@ -266,20 +266,10 @@ proc integerToColor {integer} {
 
 proc chooseColor {label initial title} {
     
-    # On macOS the initial color paramater seems broken.
-    
-    if {[tk windowingsystem] eq "aqua"} {
-    
-        set color [tk_chooseColor   -title $title -parent [winfo toplevel $label]]
-                                    
-    } else {
-    
-        set color [tk_chooseColor   -initialcolor [::integerToColor $initial] \
-                                    -title $title \
-                                    -parent [winfo toplevel $label]]
+    set color [tk_chooseColor   -initialcolor [::integerToColor $initial] \
+                                -title $title \
+                                -parent [winfo toplevel $label]]
 
-    }
-    
     if {$color ne ""} {
         $label configure -background $color
         return [::colorToInteger $color]


### PR DESCRIPTION
## Proposed Changes

  - In ActiveTcl 8.6.8 the initial color in tk_chooseColor seems to work.
  - So bring it back.
  - Add happiness in help patches with a touch of orange.
