### PR TITLE
Force undo manager to rebuild DSP graph

### DIFF
--- a/src/dsp/graph/d_block.c
+++ b/src/dsp/graph/d_block.c
@@ -165,13 +165,13 @@ static void block_setProceed (t_block *x, t_symbol *s, int argc, t_atom *argv)
 
 static void block_set (t_block *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int oldState = dsp_suspend();
+    int state = dsp_suspend();
     
     buffer_clear (x->bk_cache); buffer_append (x->bk_cache, argc, argv);
     
     block_setProceed (x, s, argc, argv);
     
-    dsp_resume (oldState);
+    dsp_resume (state);
 }
 
 static void block_float (t_block *x, t_float f)

--- a/src/undo/m_undomanager.c
+++ b/src/undo/m_undomanager.c
@@ -9,6 +9,7 @@
 #include "../m_spaghettis.h"
 #include "../m_core.h"
 #include "../s_system.h"
+#include "../d_dsp.h"
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
@@ -132,6 +133,8 @@ void undomanager_undo (t_undomanager *x)
     
     if (!instance_undoIsRecursive()) {
     //
+    int state = dsp_suspend();
+    
     instance_undoSetRecursive();
 
     {
@@ -152,6 +155,8 @@ void undomanager_undo (t_undomanager *x)
     }
     
     instance_undoUnsetRecursive();
+    
+    dsp_resume (state);
     //
     }
 }
@@ -162,6 +167,8 @@ void undomanager_redo (t_undomanager *x)
     
     if (!instance_undoIsRecursive()) {
     //
+    int state = dsp_suspend();
+    
     instance_undoSetRecursive();
 
     {
@@ -182,6 +189,8 @@ void undomanager_redo (t_undomanager *x)
     }
     
     instance_undoUnsetRecursive();
+    
+    dsp_resume (state);
     //
     }
 }


### PR DESCRIPTION
## Proposed Changes

  - Extend the scope of suspend/resume to avoid multiple DSP graph builds.
  - It fixes also cases when it is not rebuild at all.
