### PR TITLE
Fix drawing box of un-GOP selected patch

### DIFF
--- a/src/graphics/patch/g_box.c
+++ b/src/graphics/patch/g_box.c
@@ -56,6 +56,8 @@ static void box_drawObject (t_glist *glist, t_object *o, char *tag, int create, 
     int c = rectangle_getBottomRightX (r);
     int d = rectangle_getBottomRightY (r);
     
+    int isSelected = glist_objectIsSelected (glist, cast_gobj (o));
+    
     if (create) {
     
         gui_vAdd ("%s.c create rectangle %d %d %d %d"
@@ -116,6 +118,15 @@ static void box_drawObject (t_glist *glist, t_object *o, char *tag, int create, 
                         glist_getTagAsString (view),
                         tag,
                         pattern);
+    }
+    
+    /* Required for edge cases (e.g. un-GOP patch). */
+    
+    {
+        gui_vAdd ("%s.c itemconfigure %sBORDER -fill #%06x\n",
+                        glist_getTagAsString (view),
+                        tag,
+                        (isSelected ? COLOR_SELECTED : COLOR_NORMAL));
     }
 }
 

--- a/src/graphics/patch/g_editor.c
+++ b/src/graphics/patch/g_editor.c
@@ -95,11 +95,11 @@ void editor_selectionAdd (t_editor *x, t_gobj *y)
 
 int editor_selectionRemove (t_editor *x, t_gobj *y)
 {
-    t_selection *s1 = NULL;
+    t_selection *s1 = x->e_selectedObjects;
     t_selection *s2 = NULL;
     
-    s1 = x->e_selectedObjects;
-    
+    if (s1) {
+    //
     if (selection_getObject (s1) == y) {
         x->e_selectedObjects = selection_getNext (x->e_selectedObjects);
         PD_MEMORY_FREE (s1);
@@ -113,6 +113,8 @@ int editor_selectionRemove (t_editor *x, t_gobj *y)
                 return 1;
             }
         }
+    }
+    //
     }
     
     return 0;


### PR DESCRIPTION
## Proposed Changes

  - Fix box not properly redrawn while a subpatch is un-GOPed.
  - Fix also a weird crash.
