### PR TITLE
 Accelerate drawing audio samples

### DIFF
--- a/src/graphics/patch/g_message.c
+++ b/src/graphics/patch/g_message.c
@@ -169,7 +169,7 @@ static void message_anything (t_message *x, t_symbol *s, int argc, t_atom *argv)
 
 void message_click (t_message *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (glist_hasWindow (x->m_owner)) {                     /* Not shown in GOP. */
+    if (glist_hasWindow (x->m_owner)) {         /* Not shown in GOP. */
     //
     if (glist_isOnScreen (x->m_owner)) {
     //
@@ -179,7 +179,7 @@ void message_click (t_message *x, t_symbol *s, int argc, t_atom *argv)
                     glist_getTagAsString (x->m_owner), 
                     box_getTag (text));
     
-    gui_flush(); clock_delay (x->m_clock, 120.0);           /* Force the GUI to update. */
+    clock_delay (x->m_clock, 120.0);
     //
     }
     //

--- a/src/s_system.h
+++ b/src/s_system.h
@@ -107,10 +107,12 @@ void        monitor_removePoller                    (int fd);
 
 void        gui_jobAdd                              (void *owner, t_glist *glist, t_drawfn f);
 void        gui_jobRemove                           (void *owner);
+int         gui_jobFlush                            (void);
+void        gui_jobClear                            (void);
 
 void        gui_vAdd                                (const char *format, ...);
 void        gui_add                                 (const char *s);
-int         gui_flush                               (void);
+void        gui_flush                               (void);
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------

--- a/src/system/s_gui.c
+++ b/src/system/s_gui.c
@@ -38,13 +38,6 @@ static int  gui_bufferTail;     /* Static. */
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
-void gui_jobClear (void);
-int  gui_jobFlush (void);
-
-// -----------------------------------------------------------------------------------------------------------
-// -----------------------------------------------------------------------------------------------------------
-// MARK: -
-
 static void gui_bufferEnlarge()
 {
     int oldSize = gui_bufferSize;
@@ -120,14 +113,9 @@ void gui_add (const char *s)
     gui_vAdd ("%s", s);
 }
 
-int gui_flush (void)
+void gui_flush (void)
 {
-    int didSomething = 0;
-    
-    didSomething |= gui_jobFlush();
-    didSomething |= gui_bufferFlush();
-
-    return didSomething;
+    gui_bufferFlush();
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/system/s_scheduler.c
+++ b/src/system/s_scheduler.c
@@ -35,6 +35,12 @@ static t_float64Atomic  scheduler_systime;          /* Static. */
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
+#define SCHEDULER_JOB   20
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
 void scheduler_setLogicalTime (t_systime t)
 {
     PD_ATOMIC_FLOAT64_WRITE (t, &scheduler_systime);
@@ -117,6 +123,7 @@ static void scheduler_mainLoop (void)
 {
     const double realTimeAtStart       = clock_getRealTimeInSeconds();
     const t_systime logicalTimeAtStart = scheduler_getLogicalTime();
+    uint64_t count = 0;
     
     midi_start();
     
@@ -131,6 +138,7 @@ static void scheduler_mainLoop (void)
     if (!PD_ATOMIC_INT32_READ (&scheduler_quit)) {
         midi_poll();
         monitor_nonBlocking();
+        if (count++ % SCHEDULER_JOB == 0) { gui_jobFlush(); }
         gui_flush();
     }
     

--- a/src/system/s_scheduler.c
+++ b/src/system/s_scheduler.c
@@ -138,7 +138,7 @@ static void scheduler_mainLoop (void)
     if (!PD_ATOMIC_INT32_READ (&scheduler_quit)) {
         midi_poll();
         monitor_nonBlocking();
-        if (count++ % SCHEDULER_JOB == 0) { gui_jobFlush(); }
+        if (count++ % SCHEDULER_JOB == 0) { gui_jobFlush(); }   // --
         gui_flush();
     }
     


### PR DESCRIPTION
**Proposed changes**
 
  - Don't evaluate all points to draw big arrays (> 256).
  - Rendering is much faster and avoid to stall the main thread.
  - Enhancement is especially visible in debug mode (with optimisation off).
