### PR TITLE
Optimize tabreceive for DSP

### DIFF
--- a/src/control/miscellaneous/x_print.c
+++ b/src/control/miscellaneous/x_print.c
@@ -60,20 +60,28 @@ static void print_pointer (t_print *x, t_gpointer *gp)
 
 static void print_list (t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
+    if (argc < PD_STRING) {
+    //
     char *t = atom_atomsToString (argc, argv);
     
     post ("%s: [ %s ]", x->x_name->s_name, t);                  // --
     
     PD_MEMORY_FREE (t);
+    //
+    } else { warning_tooManyCharacters (sym_print); }
 }
 
 static void print_anything (t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
+    if (argc < PD_STRING) {
+    //
     char *t = atom_atomsToString (argc, argv);
     
     post ("%s: %s [ %s ]", x->x_name->s_name, s->s_name, t);    // --
     
     PD_MEMORY_FREE (t);
+    //
+    } else { warning_tooManyCharacters (sym_print); }
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/control/tab/x_tabreceive.c
+++ b/src/control/tab/x_tabreceive.c
@@ -41,15 +41,19 @@ static void tabreceive_dissmiss (t_tabreceive *);
 
 static void tabreceive_output (t_tabreceive *x, t_garray *garray)
 {
-    int n = garray_getSize (garray);
-    int i, k = 0;
+    int i;
+    int k = 0;
+    int n = 0;
+    t_word *data = NULL;
+    
+    garray_getData (garray, &n, &data);
     
     if (n != buffer_getSize (x->x_previous)) { k = 1; buffer_resize (x->x_previous, n); }
     
     for (i = 0; i < n; i++) {
         t_atom *a = buffer_getAtomAtIndex (x->x_previous, i);
-        t_float v = garray_getDataAtIndex (garray, i);
         t_float f = atom_getFloat (a);
+        t_float v = w_getFloat (data + i);
         if (f != v) { k = 1; }
         SET_FLOAT (a, v);
     }


### PR DESCRIPTION
Fixes #146

**Proposed changes**
 
  - Disallow [print] to handle too long list (that should be rejected anyway). 
  - Optimize the read of values of the array. 

