### PR TITLE
 Limit need to rebuild DSP for undo 

### DIFF
--- a/projects/Spaghettis.xcodeproj/project.pbxproj
+++ b/projects/Spaghettis.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		17AC13952295768D00D5B1EA /* x_listscramble.c in Sources */ = {isa = PBXBuildFile; fileRef = 17AC13942295768C00D5B1EA /* x_listscramble.c */; };
 		17AC139722958D8300D5B1EA /* x_listsort.c in Sources */ = {isa = PBXBuildFile; fileRef = 17AC139622958D8300D5B1EA /* x_listsort.c */; };
 		17ACD8191FA46D3B00E4DB71 /* x_counter.c in Sources */ = {isa = PBXBuildFile; fileRef = 17ACD8181FA46D3B00E4DB71 /* x_counter.c */; };
+		17AFE92B22AE241D0035E4BE /* m_undotrigger.c in Sources */ = {isa = PBXBuildFile; fileRef = 17AFE92A22AE241D0035E4BE /* m_undotrigger.c */; };
 		17B0BDD222A6B3D6004C0C29 /* m_items.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B0BDD122A6B3D6004C0C29 /* m_items.c */; };
 		17B168F822672256009EDB39 /* m_pending.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B168F722672256009EDB39 /* m_pending.c */; };
 		17B1B572215FB9AB0067D398 /* m_encapsulate.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B1B571215FB9AB0067D398 /* m_encapsulate.c */; };
@@ -569,6 +570,7 @@
 		17AC13942295768C00D5B1EA /* x_listscramble.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_listscramble.c; sourceTree = "<group>"; };
 		17AC139622958D8300D5B1EA /* x_listsort.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_listsort.c; sourceTree = "<group>"; };
 		17ACD8181FA46D3B00E4DB71 /* x_counter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_counter.c; sourceTree = "<group>"; };
+		17AFE92A22AE241D0035E4BE /* m_undotrigger.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_undotrigger.c; sourceTree = "<group>"; };
 		17B0BDD122A6B3D6004C0C29 /* m_items.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_items.c; sourceTree = "<group>"; };
 		17B168F722672256009EDB39 /* m_pending.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_pending.c; sourceTree = "<group>"; };
 		17B1B571215FB9AB0067D398 /* m_encapsulate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_encapsulate.c; sourceTree = "<group>"; };
@@ -1198,6 +1200,7 @@
 				174B465B2147FDE400B9A939 /* m_undosnippet.c */,
 				17BB46112140188E000C7C11 /* m_undoaction.c */,
 				17FBC6E2212DB385001D6A87 /* m_undomanager.c */,
+				17AFE92A22AE241D0035E4BE /* m_undotrigger.c */,
 				17F45C85213E843D005A8364 /* m_undocollapse.c */,
 				17C0B2F4212FD4B300DF3E2A /* m_undoseparator.c */,
 				17FFB4BE213A784B00921D25 /* m_undoadd.c */,
@@ -2464,6 +2467,7 @@
 				370793CD1DBB551300183F74 /* x_ctlin.c in Sources */,
 				370793E61DBB55A700183F74 /* x_midiin.c in Sources */,
 				370793E71DBB55A700183F74 /* x_notein.c in Sources */,
+				17AFE92B22AE241D0035E4BE /* m_undotrigger.c in Sources */,
 				37B6D30B1DBBB16000ECF049 /* x_sysexin.c in Sources */,
 				376963301DBFB4C4001B91B5 /* d_perform.c in Sources */,
 				37B1AA571DC1EE3E0017355A /* x_samplerate.c in Sources */,

--- a/projects/Spaghettis.xcodeproj/project.pbxproj
+++ b/projects/Spaghettis.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		17AC139722958D8300D5B1EA /* x_listsort.c in Sources */ = {isa = PBXBuildFile; fileRef = 17AC139622958D8300D5B1EA /* x_listsort.c */; };
 		17ACD8191FA46D3B00E4DB71 /* x_counter.c in Sources */ = {isa = PBXBuildFile; fileRef = 17ACD8181FA46D3B00E4DB71 /* x_counter.c */; };
 		17AFE92B22AE241D0035E4BE /* m_undotrigger.c in Sources */ = {isa = PBXBuildFile; fileRef = 17AFE92A22AE241D0035E4BE /* m_undotrigger.c */; };
+		17AFE92D22AE3B1F0035E4BE /* m_undosafe.c in Sources */ = {isa = PBXBuildFile; fileRef = 17AFE92C22AE3B1E0035E4BE /* m_undosafe.c */; };
 		17B0BDD222A6B3D6004C0C29 /* m_items.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B0BDD122A6B3D6004C0C29 /* m_items.c */; };
 		17B168F822672256009EDB39 /* m_pending.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B168F722672256009EDB39 /* m_pending.c */; };
 		17B1B572215FB9AB0067D398 /* m_encapsulate.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B1B571215FB9AB0067D398 /* m_encapsulate.c */; };
@@ -571,6 +572,7 @@
 		17AC139622958D8300D5B1EA /* x_listsort.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_listsort.c; sourceTree = "<group>"; };
 		17ACD8181FA46D3B00E4DB71 /* x_counter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_counter.c; sourceTree = "<group>"; };
 		17AFE92A22AE241D0035E4BE /* m_undotrigger.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_undotrigger.c; sourceTree = "<group>"; };
+		17AFE92C22AE3B1E0035E4BE /* m_undosafe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_undosafe.c; sourceTree = "<group>"; };
 		17B0BDD122A6B3D6004C0C29 /* m_items.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_items.c; sourceTree = "<group>"; };
 		17B168F722672256009EDB39 /* m_pending.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_pending.c; sourceTree = "<group>"; };
 		17B1B571215FB9AB0067D398 /* m_encapsulate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_encapsulate.c; sourceTree = "<group>"; };
@@ -1200,6 +1202,7 @@
 				174B465B2147FDE400B9A939 /* m_undosnippet.c */,
 				17BB46112140188E000C7C11 /* m_undoaction.c */,
 				17FBC6E2212DB385001D6A87 /* m_undomanager.c */,
+				17AFE92C22AE3B1E0035E4BE /* m_undosafe.c */,
 				17AFE92A22AE241D0035E4BE /* m_undotrigger.c */,
 				17F45C85213E843D005A8364 /* m_undocollapse.c */,
 				17C0B2F4212FD4B300DF3E2A /* m_undoseparator.c */,
@@ -2398,6 +2401,7 @@
 				375E88DF1D901BA90052D22C /* x_listinlet.c in Sources */,
 				37D724771D92768600408D24 /* x_pipe.c in Sources */,
 				37D724A01D92788800408D24 /* x_timer.c in Sources */,
+				17AFE92D22AE3B1F0035E4BE /* m_undosafe.c in Sources */,
 				37D724D41D9279A800408D24 /* x_line.c in Sources */,
 				37D724FC1D927A9A00408D24 /* x_delay.c in Sources */,
 				171741441FCEB5240083B19B /* d_greater.c in Sources */,

--- a/src/amalgam.cpp
+++ b/src/amalgam.cpp
@@ -66,6 +66,7 @@
 #include "undo/m_undosnippet.c"
 #include "undo/m_undoaction.c"
 #include "undo/m_undomanager.c"
+#include "undo/m_undotrigger.c"
 #include "undo/m_undocollapse.c"
 #include "undo/m_undoseparator.c"
 #include "undo/m_undoadd.c"

--- a/src/amalgam.cpp
+++ b/src/amalgam.cpp
@@ -66,6 +66,7 @@
 #include "undo/m_undosnippet.c"
 #include "undo/m_undoaction.c"
 #include "undo/m_undomanager.c"
+#include "undo/m_undosafe.c"
 #include "undo/m_undotrigger.c"
 #include "undo/m_undocollapse.c"
 #include "undo/m_undoseparator.c"

--- a/src/graphics/patch/g_glist.c
+++ b/src/graphics/patch/g_glist.c
@@ -45,7 +45,7 @@ static t_glist *glist_new (t_glist *owner,
     x->gl_holder            = gmaster_createWithGlist (x);
     x->gl_parent            = owner;
     x->gl_environment       = instance_environmentFetchIfAny();
-    x->gl_undomanager       = undomanager_new();
+    x->gl_undomanager       = undomanager_new (x);
     x->gl_name              = (name != &s_ ? name : environment_getFileName (x->gl_environment));
     x->gl_editor            = editor_new (x);
     x->gl_sorterObjects     = buffer_new();

--- a/src/graphics/patch/g_object.c
+++ b/src/graphics/patch/g_object.c
@@ -38,7 +38,11 @@ static int gobj_hasDSPProceed (t_gobj *x, int k)
         return k ? 1 : garray_isUsedInDSP (a);
     }
     
-    return class_hasDSP (pd_class (x));
+    if (pd_class (x) == vinlet_class)       { return vinlet_isSignal ((t_vinlet *)x);   }
+    else if (pd_class (x) == voutlet_class) { return voutlet_isSignal ((t_voutlet *)x); }
+    else {
+        return class_hasDSP (pd_class (x));
+    }
 }
 
 int gobj_hasDSPOrIsGraphicArray (t_gobj *x)

--- a/src/graphics/patch/g_object.c
+++ b/src/graphics/patch/g_object.c
@@ -25,7 +25,7 @@ extern t_widgetbehavior text_widgetBehavior;
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
 
-int gobj_hasDSP (t_gobj *x)
+static int gobj_hasDSPProceed (t_gobj *x, int k)
 {
     t_garray *a = NULL;
     
@@ -35,10 +35,20 @@ int gobj_hasDSP (t_gobj *x)
     }
     
     if (a) {
-        return garray_isUsedInDSP (a);
+        return k ? 1 : garray_isUsedInDSP (a);
     }
     
     return class_hasDSP (pd_class (x));
+}
+
+int gobj_hasDSPOrIsGraphicArray (t_gobj *x)
+{
+    return gobj_hasDSPProceed (x, 1);
+}
+
+int gobj_hasDSP (t_gobj *x)
+{
+    return gobj_hasDSPProceed (x, 0);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/undo/m_undo.h
+++ b/src/undo/m_undo.h
@@ -58,6 +58,7 @@ typedef struct _undoaction {
 
 typedef struct _undomanager {
     int                 um_count;
+    t_glist             *um_owner;
     t_clock             *um_clock;
     t_undoaction        *um_head;
     t_undoaction        *um_tail;
@@ -96,7 +97,7 @@ static inline t_symbol *undoaction_getLabel (t_undoaction *a)
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
-t_undomanager   *undomanager_new            (void);
+t_undomanager   *undomanager_new            (t_glist *owner);
 
 void    undomanager_free                    (t_undomanager *x);
 

--- a/src/undo/m_undo.h
+++ b/src/undo/m_undo.h
@@ -44,6 +44,7 @@ typedef struct _undoaction {
     t_pd                ua_pd;              /* Must be the first. */
     t_id                ua_id;
     t_undotype          ua_type;
+    int                 ua_safe;            /* Don't need to suspend DSP. */
     int                 ua_inlet;           /* Inlet created or deleted. */
     int                 ua_inletIndex;      /* Inlet index. */
     int                 ua_outlet;
@@ -88,6 +89,11 @@ static inline t_undotype undoaction_getType (t_undoaction *a)
     return a->ua_type;
 }
 
+static inline int undoaction_suspend (t_undoaction *a)
+{
+    return (a->ua_safe == 0);
+}
+
 static inline t_symbol *undoaction_getLabel (t_undoaction *a)
 {
     return a->ua_label;
@@ -111,6 +117,13 @@ void    undomanager_redo                    (t_undomanager *x);
 
 t_symbol    *undomanager_getUndoLabel       (t_undomanager *x);
 t_symbol    *undomanager_getRedoLabel       (t_undomanager *x);
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
+int undomanager_undoNeedToSuspend           (t_undomanager *x);
+int undomanager_redoNeedToSuspend           (t_undomanager *x);
 
 int undomanager_undoNeedToTriggerParent     (t_undomanager *x, t_items *inlets, t_items *outlets);
 int undomanager_redoNeedToTriggerParent     (t_undomanager *x, t_items *inlets, t_items *outlets);

--- a/src/undo/m_undoadd.c
+++ b/src/undo/m_undoadd.c
@@ -31,6 +31,7 @@ t_undoaction *undoadd_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undoadd_class);
     
     x->ua_type  = UNDO_ADD;
+    x->ua_safe  = 1;
     x->ua_label = sym_add;
     
     return x;

--- a/src/undo/m_undoback.c
+++ b/src/undo/m_undoback.c
@@ -48,9 +48,10 @@ t_undoaction *undoback_new (t_gobj *o, t_undosnippet *snippet)
     t_undoaction *x = (t_undoaction *)pd_new (undoback_class);
     t_undoback *z   = (t_undoback *)x;
     
-    x->ua_id     = gobj_getUnique (o);
-    x->ua_type   = UNDO_BACK;
-    x->ua_label  = sym_back;
+    x->ua_id    = gobj_getUnique (o);
+    x->ua_type  = UNDO_BACK;
+    x->ua_safe  = 1;
+    x->ua_label = sym_back;
     
     PD_ASSERT (snippet);
     

--- a/src/undo/m_undoconnect.c
+++ b/src/undo/m_undoconnect.c
@@ -51,7 +51,10 @@ t_undoaction *undoconnect_new (t_object *src, int m, t_object *dest, int n)
     t_undoaction *x  = (t_undoaction *)pd_new (undoconnect_class);
     t_undoconnect *z = (t_undoconnect *)x;
     
+    int safe = (object_isSignalOutlet (src, m) == 0);
+    
     x->ua_type  = UNDO_CONNECT;
+    x->ua_safe  = safe;
     x->ua_label = sym_connect;
     
     z->x_src    = gobj_getUnique (cast_gobj (src));

--- a/src/undo/m_undocreate.c
+++ b/src/undo/m_undocreate.c
@@ -29,6 +29,12 @@ typedef struct _undocreate {
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
+int gobj_hasDSPOrIsGraphicArray (t_gobj *);
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
 void undocreate_undo (t_undocreate *z, t_symbol *s, int argc, t_atom *argv)
 {
     t_undoaction *x = (t_undoaction *)z;
@@ -52,8 +58,13 @@ t_undoaction *undocreate_new (t_gobj *o, t_undosnippet *snippet)
     t_undoaction *x = (t_undoaction *)pd_new (undocreate_class);
     t_undocreate *z = (t_undocreate *)x;
     
+    // -- TODO: Consider if arrays always require to rebuild the graph?
+    
+    int safe = (gobj_hasDSPOrIsGraphicArray (o) == 0);
+    
     x->ua_id    = gobj_getUnique (o);
     x->ua_type  = UNDO_CREATE;
+    x->ua_safe  = safe;
     x->ua_label = sym_create;
 
     undoaction_setInletsAndOutlets (x, o);

--- a/src/undo/m_undocut.c
+++ b/src/undo/m_undocut.c
@@ -31,6 +31,7 @@ t_undoaction *undocut_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undocut_class);
     
     x->ua_type  = UNDO_CUT;
+    x->ua_safe  = 1;
     x->ua_label = sym_cut;
     
     return x;

--- a/src/undo/m_undodeencapsulate.c
+++ b/src/undo/m_undodeencapsulate.c
@@ -31,6 +31,7 @@ t_undoaction *undodeencapsulate_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undodeencapsulate_class);
     
     x->ua_type  = UNDO_DEENCAPSULATE;
+    x->ua_safe  = 0;
     x->ua_label = sym_de__dash__encapsulate;
     
     return x;

--- a/src/undo/m_undodelete.c
+++ b/src/undo/m_undodelete.c
@@ -29,6 +29,12 @@ typedef struct _undodelete {
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
+int gobj_hasDSPOrIsGraphicArray (t_gobj *);
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
 void undodelete_undo (t_undodelete *z, t_symbol *s, int argc, t_atom *argv)
 {
     undosnippet_load (z->x_snippet); undosnippet_z (z->x_snippet);
@@ -50,8 +56,13 @@ t_undoaction *undodelete_new (t_gobj *o, t_undosnippet *snippet)
     t_undoaction *x = (t_undoaction *)pd_new (undodelete_class);
     t_undodelete *z = (t_undodelete *)x;
     
+    // -- TODO: Consider if arrays always require to rebuild the graph?
+    
+    int safe = (gobj_hasDSPOrIsGraphicArray (o) == 0);
+
     x->ua_id    = gobj_getUnique (o);
     x->ua_type  = UNDO_DELETE;
+    x->ua_safe  = safe;
     x->ua_label = sym_delete;
     
     undoaction_setInletsAndOutlets (x, o);

--- a/src/undo/m_undodisconnect.c
+++ b/src/undo/m_undodisconnect.c
@@ -69,7 +69,10 @@ t_undoaction *undodisconnect_new (t_object *src, int m, t_object *dest, int n)
     t_undoaction *x = (t_undoaction *)pd_new (undodisconnect_class);
     t_undodisconnect *z = (t_undodisconnect *)x;
     
+    int safe = (object_isSignalOutlet (src, m) == 0);
+
     x->ua_type  = UNDO_DISCONNECT;
+    x->ua_safe  = safe;
     x->ua_label = sym_disconnect;
     
     z->x_src    = gobj_getUnique (cast_gobj (src));

--- a/src/undo/m_undoduplicate.c
+++ b/src/undo/m_undoduplicate.c
@@ -31,6 +31,7 @@ t_undoaction *undoduplicate_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undoduplicate_class);
     
     x->ua_type  = UNDO_DUPLICATE;
+    x->ua_safe  = 1;
     x->ua_label = sym_duplicate;
     
     return x;

--- a/src/undo/m_undoencapsulate.c
+++ b/src/undo/m_undoencapsulate.c
@@ -31,6 +31,7 @@ t_undoaction *undoencapsulate_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undoencapsulate_class);
     
     x->ua_type  = UNDO_ENCAPSULATE;
+    x->ua_safe  = 0;
     x->ua_label = sym_encapsulate;
     
     return x;

--- a/src/undo/m_undofront.c
+++ b/src/undo/m_undofront.c
@@ -48,9 +48,10 @@ t_undoaction *undofront_new (t_gobj *o, t_undosnippet *snippet)
     t_undoaction *x = (t_undoaction *)pd_new (undofront_class);
     t_undofront *z  = (t_undofront *)x;
     
-    x->ua_id     = gobj_getUnique (o);
-    x->ua_type   = UNDO_FRONT;
-    x->ua_label  = sym_front;
+    x->ua_id    = gobj_getUnique (o);
+    x->ua_type  = UNDO_FRONT;
+    x->ua_safe  = 1;
+    x->ua_label = sym_front;
     
     PD_ASSERT (snippet);
     

--- a/src/undo/m_undomanager.c
+++ b/src/undo/m_undomanager.c
@@ -151,13 +151,17 @@ void undomanager_append (t_undomanager *x, t_undoaction *a)
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
+/* Notice that DSP is suspended globally only to avoid unnecessary consecutive rebuilds. */
+
 void undomanager_undo (t_undomanager *x)
 {
     clock_unset (x->um_clock);
     
     if (!instance_undoIsRecursive()) {
     //
-    int state = dsp_suspend();
+    int dspState, dspSuspended = undomanager_undoNeedToSuspend (x);
+    
+    if (dspSuspended) { dspState = dsp_suspend(); }
     
     instance_undoSetRecursive();
 
@@ -184,7 +188,7 @@ void undomanager_undo (t_undomanager *x)
     
     instance_undoUnsetRecursive();
     
-    dsp_resume (state);
+    if (dspSuspended) { dsp_resume (dspState); }
     //
     }
 }
@@ -195,7 +199,9 @@ void undomanager_redo (t_undomanager *x)
     
     if (!instance_undoIsRecursive()) {
     //
-    int state = dsp_suspend();
+    int dspState, dspSuspended = undomanager_redoNeedToSuspend (x);
+    
+    if (dspSuspended) { dspState = dsp_suspend(); }
     
     instance_undoSetRecursive();
 
@@ -222,7 +228,7 @@ void undomanager_redo (t_undomanager *x)
     
     instance_undoUnsetRecursive();
     
-    dsp_resume (state);
+    if (dspSuspended) { dsp_resume (dspState); }
     //
     }
 }

--- a/src/undo/m_undomotion.c
+++ b/src/undo/m_undomotion.c
@@ -75,6 +75,7 @@ t_undoaction *undomotion_new (t_gobj *o, int deltaX, int deltaY)
     
     x->ua_id    = gobj_getUnique (o);
     x->ua_type  = UNDO_MOTION;
+    x->ua_safe  = 1;
     x->ua_label = sym_motion;
     
     z->x_deltaX = deltaX;

--- a/src/undo/m_undopaste.c
+++ b/src/undo/m_undopaste.c
@@ -31,6 +31,7 @@ t_undoaction *undopaste_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undopaste_class);
     
     x->ua_type  = UNDO_PASTE;
+    x->ua_safe  = 1;
     x->ua_label = sym_paste;
     
     return x;

--- a/src/undo/m_undoproperties.c
+++ b/src/undo/m_undoproperties.c
@@ -49,8 +49,15 @@ t_undoaction *undoproperties_new (t_gobj *o, t_undosnippet *s1, t_undosnippet *s
     t_undoaction *x = (t_undoaction *)pd_new (undoproperties_class);
     t_undoproperties *z = (t_undoproperties *)x;
     
+    /* Changing garray's size in property window requires to rebuild the graph. */
+    /* Assume it is rarely the case, optimistically set the undo action as safe. */
+    /* Note that the rebuild will be properly handled in the resizing function anyway. */
+    
+    int safe = 1;
+    
     x->ua_id    = gobj_getUnique (o);
     x->ua_type  = UNDO_PROPERTIES;
+    x->ua_safe  = safe;
     x->ua_label = sym_properties;
     
     PD_ASSERT (s1);

--- a/src/undo/m_undoremove.c
+++ b/src/undo/m_undoremove.c
@@ -31,6 +31,7 @@ t_undoaction *undoremove_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undoremove_class);
     
     x->ua_type  = UNDO_REMOVE;
+    x->ua_safe  = 1;
     x->ua_label = sym_remove;
     
     return x;

--- a/src/undo/m_undoresizebox.c
+++ b/src/undo/m_undoresizebox.c
@@ -70,6 +70,7 @@ t_undoaction *undoresizebox_new (t_gobj *o, int m, int n)
     
     x->ua_id    = gobj_getUnique (o);
     x->ua_type  = UNDO_RESIZE_BOX;
+    x->ua_safe  = 1;
     x->ua_label = sym_resize;
     
     z->x_old    = m;

--- a/src/undo/m_undoresizegraph.c
+++ b/src/undo/m_undoresizegraph.c
@@ -70,6 +70,7 @@ t_undoaction *undoresizegraph_proceed (t_gobj *o, t_rectangle *old, t_rectangle 
     
     x->ua_id    = gobj_getUnique (o);
     x->ua_type  = UNDO_RESIZE_GRAPH;
+    x->ua_safe  = 1;
     x->ua_label = label;
     
     rectangle_setCopy (&z->x_old, old);

--- a/src/undo/m_undosafe.c
+++ b/src/undo/m_undosafe.c
@@ -1,0 +1,50 @@
+
+/* Copyright (c) 1997-2019 Miller Puckette and others. */
+
+/* < https://opensource.org/licenses/BSD-3-Clause > */
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+
+#include "../m_spaghettis.h"
+#include "../m_core.h"
+#include "../g_graphics.h"
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
+int undomanager_undoNeedToSuspend (t_undomanager *x)
+{
+    t_undoaction *a = x->um_tail;
+
+    while (a && a->ua_previous) {
+    
+        if (undoaction_suspend (a)) { return 1; }
+        
+        a = a->ua_previous;
+        
+        if (undoaction_getType (a) == UNDO_SEPARATOR) { break; }
+    }
+    
+    return 0;
+}
+
+int undomanager_redoNeedToSuspend (t_undomanager *x)
+{
+    t_undoaction *a = x->um_tail;
+    
+    while (a) {
+    
+        if (undoaction_suspend (a)) { return 1; }
+        
+        if (a->ua_next == NULL) { break; } else { a = a->ua_next; }
+        
+        if (undoaction_getType (a) == UNDO_SEPARATOR) { break; }
+    }
+    
+    return 0;
+}
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------

--- a/src/undo/m_undoseparator.c
+++ b/src/undo/m_undoseparator.c
@@ -32,6 +32,7 @@ t_undoaction *undoseparator_new (void)
     
     x->ua_id    = 0;
     x->ua_type  = UNDO_SEPARATOR;
+    x->ua_safe  = 1;
     x->ua_label = sym_separator;
     
     return x;

--- a/src/undo/m_undosnap.c
+++ b/src/undo/m_undosnap.c
@@ -31,6 +31,7 @@ t_undoaction *undosnap_new (void)
     t_undoaction *x = (t_undoaction *)pd_new (undosnap_class);
     
     x->ua_type  = UNDO_SNAP;
+    x->ua_safe  = 1;
     x->ua_label = sym_snap;
     
     return x;

--- a/src/undo/m_undotrigger.c
+++ b/src/undo/m_undotrigger.c
@@ -1,0 +1,121 @@
+
+/* Copyright (c) 1997-2019 Miller Puckette and others. */
+
+/* < https://opensource.org/licenses/BSD-3-Clause > */
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+
+#include "../m_spaghettis.h"
+#include "../m_core.h"
+#include "../s_system.h"
+#include "../d_dsp.h"
+#include "../g_graphics.h"
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
+t_undoaction *undomanager_getUndoAction (t_undomanager *);
+t_undoaction *undomanager_getRedoAction (t_undomanager *);
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+
+int undodisconnect_match (t_undoaction *, t_id, t_items *, t_items *);
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
+static int undomanager_undoContainsDelete (t_undomanager *x, t_items *i, t_items *o)
+{
+    int k = 0;
+    
+    t_undoaction *a = x->um_tail;
+
+    while (a && a->ua_previous) {
+    
+        if (undoaction_getType (a) == UNDO_DELETE) { k |= undoaction_getInletsAndOutlets (a, i, o); }
+        
+        a = a->ua_previous;
+        
+        if (undoaction_getType (a) == UNDO_SEPARATOR) { break; }
+    }
+    
+    return k;
+}
+
+int undomanager_undoNeedToTriggerParent (t_undomanager *x, t_items *i, t_items *o)
+{
+    t_undoaction *a = undomanager_getUndoAction (x);
+    
+    if (a && undoaction_getType (a) == UNDO_REMOVE) { return undomanager_undoContainsDelete (x, i, o); }
+    
+    return 0;
+}
+
+static int undomanager_redoContainsCreate (t_undomanager *x, t_items *i, t_items *o)
+{
+    int k = 0;
+    
+    t_undoaction *a = x->um_tail;
+    
+    while (a) {
+    
+        if (undoaction_getType (a) == UNDO_CREATE) { k |= undoaction_getInletsAndOutlets (a, i, o); }
+        
+        if (a->ua_next == NULL) { break; } else { a = a->ua_next; }
+        
+        if (undoaction_getType (a) == UNDO_SEPARATOR) { break; }
+    }
+    
+    return k;
+}
+
+int undomanager_redoNeedToTriggerParent (t_undomanager *x, t_items *i, t_items *o)
+{
+    t_undoaction *a = undomanager_getRedoAction (x);
+    
+    if (a && undoaction_getType (a) == UNDO_ADD) { return undomanager_redoContainsCreate (x, i, o); }
+    
+    return 0;
+}
+
+static int undomanager_undoContainsDisconnect (t_undomanager *x, t_glist *glist, t_items *i, t_items *o)
+{
+    t_id u = gobj_getUnique (cast_gobj (glist));
+    
+    t_undoaction *a = x->um_tail;
+
+    while (a && a->ua_previous) {
+    
+        if (undodisconnect_match (a, u, i, o)) { } else if (undoaction_getType (a) != UNDO_SEPARATOR) {
+            return 0;
+        }
+        
+        a = a->ua_previous;
+        
+        if (undoaction_getType (a) == UNDO_SEPARATOR) { break; }
+    }
+    
+    return 1;
+}
+
+int undomanager_triggerParentIsPossible (t_glist *glist, t_items *i, t_items *o)
+{
+    if (glist_hasParent (glist)) {
+    //
+    t_glist *parent = glist_getParent (glist);
+    
+    if (undomanager_undoContainsDisconnect (glist_getUndoManager (parent), glist, i, o)) {
+        return 1;
+    }
+    //
+    }
+    
+    return 0;
+}
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------

--- a/src/undo/m_undotrigger.c
+++ b/src/undo/m_undotrigger.c
@@ -8,8 +8,6 @@
 
 #include "../m_spaghettis.h"
 #include "../m_core.h"
-#include "../s_system.h"
-#include "../d_dsp.h"
 #include "../g_graphics.h"
 
 // -----------------------------------------------------------------------------------------------------------
@@ -21,6 +19,7 @@ t_undoaction *undomanager_getRedoAction (t_undomanager *);
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
+// MARK: -
 
 int undodisconnect_match (t_undoaction *, t_id, t_items *, t_items *);
 
@@ -55,6 +54,10 @@ int undomanager_undoNeedToTriggerParent (t_undomanager *x, t_items *i, t_items *
     return 0;
 }
 
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
 static int undomanager_redoContainsCreate (t_undomanager *x, t_items *i, t_items *o)
 {
     int k = 0;
@@ -81,6 +84,10 @@ int undomanager_redoNeedToTriggerParent (t_undomanager *x, t_items *i, t_items *
     
     return 0;
 }
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
 
 static int undomanager_undoContainsDisconnect (t_undomanager *x, t_glist *glist, t_items *i, t_items *o)
 {

--- a/src/undo/m_undotyping.c
+++ b/src/undo/m_undotyping.c
@@ -51,6 +51,7 @@ t_undoaction *undotyping_new (t_gobj *o, t_undosnippet *s1, t_undosnippet *s2)
     
     x->ua_id    = gobj_getUnique (o);
     x->ua_type  = UNDO_TYPING;
+    x->ua_safe  = 1;
     x->ua_label = sym_typing;
     
     PD_ASSERT (s1);


### PR DESCRIPTION
Fixes #143

**Proposed changes**
 
  - Check if undo action might need to rebuild the DSP graph.
  - Suspend DSP for Undo/Redo globally only if required.
  - Reduce number of Undo/Redo for fragmented actions (resize, motion...).
