### PR TITLE
Fix type consistency at addition to dsp chain

### DIFF
--- a/src/dsp/convert/d_env.c
+++ b/src/dsp/convert/d_env.c
@@ -143,7 +143,7 @@ static void env_tilde_dsp (t_env_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (env_tilde_perform, 3, x, sp[0]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (env_tilde_perform, x, sp[0]->s_vector, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/convert/d_line.c
+++ b/src/dsp/convert/d_line.c
@@ -169,7 +169,7 @@ static void line_tilde_dsp (t_line_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (line_tilde_perform, 4, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add4 (line_tilde_perform, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/convert/d_samphold.c
+++ b/src/dsp/convert/d_samphold.c
@@ -93,7 +93,7 @@ static void samphold_tilde_dsp (t_samphold_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (samphold_tilde_perform, 5, x,
+    dsp_add5 (samphold_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector, 

--- a/src/dsp/convert/d_snapshot.c
+++ b/src/dsp/convert/d_snapshot.c
@@ -73,7 +73,7 @@ static void snapshot_tilde_dsp (t_snapshot_tilde *x, t_signal **sp)
 {
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
     
-    dsp_add (snapshot_tilde_perform, 2, sp[0]->s_vector + (sp[0]->s_vectorSize - 1), &x->x_value);
+    dsp_add2 (snapshot_tilde_perform, sp[0]->s_vector + (sp[0]->s_vectorSize - 1), &x->x_value);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/convert/d_threshold.c
+++ b/src/dsp/convert/d_threshold.c
@@ -180,7 +180,7 @@ void threshold_tilde_dsp (t_threshold_tilde *x, t_signal **sp)
     
     pthread_mutex_unlock (&x->x_mutex);
     
-    dsp_add (threshold_tilde_perform, 4, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add4 (threshold_tilde_perform, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/delay/d_delread.c
+++ b/src/dsp/delay/d_delread.c
@@ -98,7 +98,7 @@ static void delread_tilde_dsp (t_delread_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (delread_tilde_perform, 5, x, &m->dw_space, sp[0]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (delread_tilde_perform, x, &m->dw_space, sp[0]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/delay/d_delwrite.c
+++ b/src/dsp/delay/d_delwrite.c
@@ -114,7 +114,7 @@ static void delwrite_tilde_dsp (t_delwrite_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (delwrite_tilde_perform, 3, &x->dw_space, sp[0]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (delwrite_tilde_perform, &x->dw_space, sp[0]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/delay/d_vd.c
+++ b/src/dsp/delay/d_vd.c
@@ -82,7 +82,7 @@ static void vd_tilde_dsp (t_vd_tilde *x, t_signal **sp)
     
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (vd_tilde_perform, 5, &m->dw_space, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (vd_tilde_perform, &m->dw_space, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/fft/d_fft.c
+++ b/src/dsp/fft/d_fft.c
@@ -69,7 +69,7 @@ static void fft_tilde_dsp (t_fft_tilde *x, t_signal **sp)
     dsp_addCopyPerform (sp[0]->s_vector, sp[2]->s_vector, n);
     dsp_addCopyPerform (sp[1]->s_vector, sp[3]->s_vector, n);
     
-    dsp_add (fft_tilde_perform, 4, t, sp[2]->s_vector, sp[3]->s_vector, n);
+    dsp_add4 (fft_tilde_perform, t, sp[2]->s_vector, sp[3]->s_vector, n);
     //
     }
 }

--- a/src/dsp/fft/d_framp.c
+++ b/src/dsp/fft/d_framp.c
@@ -128,7 +128,7 @@ static void framp_tilde_dsp (t_framp_tilde *x, t_signal **sp)
     //
     int half = (n >> 1);
     
-    dsp_add (framp_tilde_perform, 5,
+    dsp_add5 (framp_tilde_perform,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector,

--- a/src/dsp/fft/d_ifft.c
+++ b/src/dsp/fft/d_ifft.c
@@ -69,7 +69,7 @@ static void ifft_tilde_dsp (t_ifft_tilde *x, t_signal **sp)
     dsp_addCopyPerform (sp[0]->s_vector, sp[2]->s_vector, n);
     dsp_addCopyPerform (sp[1]->s_vector, sp[3]->s_vector, n);
     
-    dsp_add (ifft_tilde_perform, 4, t, sp[2]->s_vector, sp[3]->s_vector, n);
+    dsp_add4 (ifft_tilde_perform, t, sp[2]->s_vector, sp[3]->s_vector, n);
     //
     }
 }

--- a/src/dsp/fft/d_rfft.c
+++ b/src/dsp/fft/d_rfft.c
@@ -85,8 +85,8 @@ static void rfft_tilde_dsp (t_rfft_tilde *x, t_signal **sp)
         
     dsp_addCopyPerform (in1, out1, n);
     
-    dsp_add (rfft_tilde_perform, 3, t, out1, n);
-    dsp_add (rfft_tilde_performFlipZero, 3, out1 + half + 1, out2 + half, half - 1);
+    dsp_add3 (rfft_tilde_perform, t, out1, n);
+    dsp_add3 (rfft_tilde_performFlipZero, out1 + half + 1, out2 + half, half - 1);
     //
     }
 }

--- a/src/dsp/fft/d_rifft.c
+++ b/src/dsp/fft/d_rifft.c
@@ -83,8 +83,8 @@ static void rifft_tilde_dsp (t_rifft_tilde *x, t_signal **sp)
         
     dsp_addCopyPerform (in1, out1, half + 1);
     
-    dsp_add (rifft_tilde_performFlip, 3, in2 + 1, out1 + n, half - 1);
-    dsp_add (rifft_tilde_perform, 3, t, out1, n);
+    dsp_add3 (rifft_tilde_performFlip, in2 + 1, out1 + n, half - 1);
+    dsp_add3 (rifft_tilde_perform, t, out1, n);
     //
     }
 }

--- a/src/dsp/fft/d_sigmund.c
+++ b/src/dsp/fft/d_sigmund.c
@@ -943,7 +943,7 @@ static void sigmund_tilde_dsp (t_sigmund_tilde *x, t_signal **sp)
     
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (sigmund_tilde_perform, 3, x, sp[0]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (sigmund_tilde_perform, x, sp[0]->s_vector, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/filters/d_biquad.c
+++ b/src/dsp/filters/d_biquad.c
@@ -170,7 +170,7 @@ static void biquad_tilde_dsp (t_biquad_tilde *x, t_signal **sp)
     
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (biquad_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (biquad_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/filters/d_bp.c
+++ b/src/dsp/filters/d_bp.c
@@ -167,7 +167,7 @@ static void bp_tilde_dsp (t_bp_tilde *x, t_signal **sp)
     
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (bp_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (bp_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/filters/d_cpole.c
+++ b/src/dsp/filters/d_cpole.c
@@ -119,7 +119,7 @@ static void cpole_tilde_dsp (t_cpole_tilde *x, t_signal **sp)
     
     complex_raw_initializer (cast_gobj (x));
     
-    dsp_add (cpole_tilde_perform, 8, x,
+    dsp_add8 (cpole_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector,

--- a/src/dsp/filters/d_czero.c
+++ b/src/dsp/filters/d_czero.c
@@ -93,7 +93,7 @@ static void czero_tilde_dsp (t_czero_tilde *x, t_signal **sp)
     
     complex_raw_initializer (cast_gobj (x));
     
-    dsp_add (czero_tilde_perform, 8, x,
+    dsp_add8 (czero_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector,

--- a/src/dsp/filters/d_czeroreverse.c
+++ b/src/dsp/filters/d_czeroreverse.c
@@ -93,7 +93,7 @@ static void czero_rev_tilde_dsp (t_czero_rev_tilde *x, t_signal **sp)
     
     complex_raw_initializer (cast_gobj (x));
     
-    dsp_add (czero_rev_tilde_perform, 8, x,
+    dsp_add8 (czero_rev_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector,

--- a/src/dsp/filters/d_hip.c
+++ b/src/dsp/filters/d_hip.c
@@ -115,7 +115,7 @@ static void hip_tilde_dsp (t_hip_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (hip_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (hip_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/filters/d_lop.c
+++ b/src/dsp/filters/d_lop.c
@@ -108,7 +108,7 @@ static void lop_tilde_dsp (t_lop_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (lop_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (lop_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/filters/d_rpole.c
+++ b/src/dsp/filters/d_rpole.c
@@ -100,7 +100,7 @@ static void rpole_tilde_dsp (t_rpole_tilde *x, t_signal **sp)
     
     real_raw_initializer (cast_gobj (x));
     
-    dsp_add (rpole_tilde_perform, 5, x,
+    dsp_add5 (rpole_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector,

--- a/src/dsp/filters/d_rzero.c
+++ b/src/dsp/filters/d_rzero.c
@@ -74,7 +74,7 @@ static void rzero_tilde_dsp (t_rzero_tilde *x, t_signal **sp)
     
     real_raw_initializer (cast_gobj (x));
     
-    dsp_add (rzero_tilde_perform, 5, x,
+    dsp_add5 (rzero_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector, 

--- a/src/dsp/filters/d_rzeroreverse.c
+++ b/src/dsp/filters/d_rzeroreverse.c
@@ -74,7 +74,7 @@ static void rzero_rev_tilde_dsp (t_rzero_rev_tilde *x, t_signal **sp)
     
     real_raw_initializer (cast_gobj (x));
     
-    dsp_add (rzero_rev_tilde_perform, 5, x,
+    dsp_add5 (rzero_rev_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector, 

--- a/src/dsp/filters/d_vcf.c
+++ b/src/dsp/filters/d_vcf.c
@@ -148,7 +148,7 @@ static void vcf_tilde_dsp (t_vcf_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (vcf_tilde_perform, 7, x,
+    dsp_add7 (vcf_tilde_perform, x,
         sp[0]->s_vector,
         sp[1]->s_vector,
         sp[2]->s_vector,

--- a/src/dsp/global/d_receive.c
+++ b/src/dsp/global/d_receive.c
@@ -93,7 +93,7 @@ static void receive_tilde_dsp (t_receive_tilde *x, t_signal **sp)
     
     PD_ASSERT ((t_sample *)PD_ATOMIC_POINTER_READ (&x->x_p) != sp[0]->s_vector);
     
-    dsp_add (receive_tilde_perform, 2, x, sp[0]->s_vector);
+    dsp_add2 (receive_tilde_perform, x, sp[0]->s_vector);
     //
     }
 }

--- a/src/dsp/global/d_throw.c
+++ b/src/dsp/global/d_throw.c
@@ -89,7 +89,7 @@ static void throw_tilde_dsp (t_throw_tilde *x, t_signal **sp)
     
     PD_ASSERT (sp[0]->s_vector != (t_sample *)PD_ATOMIC_POINTER_READ (&x->x_p));
     
-    dsp_add (throw_tilde_perform, 2, x, sp[0]->s_vector);
+    dsp_add2 (throw_tilde_perform, x, sp[0]->s_vector);
     //
     }
 }

--- a/src/dsp/graph/d_functions.c
+++ b/src/dsp/graph/d_functions.c
@@ -80,9 +80,9 @@ void dsp_addClipPerform (PD_RESTRICTED dest, int n)
     
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_clip, 2, dest, n); }
+    if (n & 7) { dsp_add2 (perform_clip, dest, n); }
     else {
-        dsp_add (vPerform_clip, 2, dest, n);
+        dsp_add2 (vPerform_clip, dest, n);
     }
 }
 
@@ -92,9 +92,9 @@ void dsp_addZeroPerform (PD_RESTRICTED dest, int n)
     
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_zero, 2, dest, n); }
+    if (n & 7) { dsp_add2 (perform_zero, dest, n); }
     else {
-        dsp_add (vPerform_zero, 2, dest, n);
+        dsp_add2 (vPerform_zero, dest, n);
     }
 }
 
@@ -104,9 +104,9 @@ void dsp_addScalarPerform (t_float64Atomic *f, PD_RESTRICTED dest, int n)
     
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_scalar, 3, f, dest, n); }
+    if (n & 7) { dsp_add3 (perform_scalar, f, dest, n); }
     else {
-        dsp_add (vPerform_scalar, 3, f, dest, n);
+        dsp_add3 (vPerform_scalar, f, dest, n);
     }
 }
 
@@ -118,9 +118,9 @@ void dsp_addCopyPerform (PD_RESTRICTED src, PD_RESTRICTED dest, int n)
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_copy, 3, src, dest, n); }
+    if (n & 7) { dsp_add3 (perform_copy, src, dest, n); }
     else {
-        dsp_add (vPerform_copy, 3, src, dest, n);
+        dsp_add3 (vPerform_copy, src, dest, n);
     }
 }
 
@@ -132,9 +132,9 @@ void dsp_addCopyZeroPerform (PD_RESTRICTED src, PD_RESTRICTED dest, int n)
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_copyZero, 3, src, dest, n); }
+    if (n & 7) { dsp_add3 (perform_copyZero, src, dest, n); }
     else {
-        dsp_add (vPerform_copyZero, 3, src, dest, n);
+        dsp_add3 (vPerform_copyZero, src, dest, n);
     }
 }
 
@@ -146,9 +146,9 @@ void dsp_addSquareRootPerform (PD_RESTRICTED src, PD_RESTRICTED dest, int n)
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_squareRoot, 3, src, dest, n); }
+    if (n & 7) { dsp_add3 (perform_squareRoot, src, dest, n); }
     else {
-        dsp_add (vPerform_squareRoot, 3, src, dest, n);
+        dsp_add3 (vPerform_squareRoot, src, dest, n);
     }
 }
 
@@ -160,9 +160,9 @@ void dsp_addInverseSquareRootPerform (PD_RESTRICTED src, PD_RESTRICTED dest, int
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_inverseSquareRoot, 3, src, dest, n); }
+    if (n & 7) { dsp_add3 (perform_inverseSquareRoot, src, dest, n); }
     else {
-        dsp_add (vPerform_inverseSquareRoot, 3, src, dest, n);
+        dsp_add3 (vPerform_inverseSquareRoot, src, dest, n);
     }
 }
 
@@ -174,9 +174,9 @@ void dsp_addPlusPerformAliased (t_sample *src1, t_sample *src2, t_sample *dest, 
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_plusAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_plusAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_plusAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_plusAliased, src1, src2, dest, n);
     }
 }
 
@@ -188,9 +188,9 @@ void dsp_addPlusScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_RESTRIC
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_plusScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_plusScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_plusScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_plusScalar, src, f, dest, n);
     }
 }
 
@@ -202,9 +202,9 @@ void dsp_addSubtractPerformAliased (t_sample *src1, t_sample *src2, t_sample *de
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_subtractAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_subtractAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_subtractAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_subtractAliased, src1, src2, dest, n);
     }
 }
 
@@ -216,9 +216,9 @@ void dsp_addSubtractScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_RES
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_subtractScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_subtractScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_subtractScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_subtractScalar, src, f, dest, n);
     }
 }
 
@@ -230,9 +230,9 @@ void dsp_addMultiplyPerformAliased (t_sample *src1, t_sample *src2, t_sample *de
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_multiplyAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_multiplyAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_multiplyAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_multiplyAliased, src1, src2, dest, n);
     }
 }
 
@@ -244,9 +244,9 @@ void dsp_addMultiplyScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_RES
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
 
-    if (n & 7) { dsp_add (perform_multiplyScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_multiplyScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_multiplyScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_multiplyScalar, src, f, dest, n);
     }
 }
 
@@ -258,9 +258,9 @@ void dsp_addDividePerformAliased (t_sample *src1, t_sample *src2, t_sample *dest
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_divideAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_divideAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_divideAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_divideAliased, src1, src2, dest, n);
     }
 }
 
@@ -272,9 +272,9 @@ void dsp_addDivideScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_RESTR
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_divideScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_divideScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_divideScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_divideScalar, src, f, dest, n);
     }
 }
 
@@ -286,9 +286,9 @@ void dsp_addMaximumPerformAliased (t_sample *src1, t_sample *src2, t_sample *des
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_maximumAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_maximumAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_maximumAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_maximumAliased, src1, src2, dest, n);
     }
 }
 
@@ -300,9 +300,9 @@ void dsp_addMaximumScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_REST
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_maximumScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_maximumScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_maximumScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_maximumScalar, src, f, dest, n);
     }
 }
 
@@ -314,9 +314,9 @@ void dsp_addMinimumPerformAliased (t_sample *src1, t_sample *src2, t_sample *des
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_minimumAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_minimumAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_minimumAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_minimumAliased, src1, src2, dest, n);
     }
 }
 
@@ -328,9 +328,9 @@ void dsp_addMinimumScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_REST
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_minimumScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_minimumScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_minimumScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_minimumScalar, src, f, dest, n);
     }
 }
 
@@ -342,9 +342,9 @@ void dsp_addGreaterPerformAliased (t_sample *src1, t_sample *src2, t_sample *des
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_greaterAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_greaterAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_greaterAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_greaterAliased, src1, src2, dest, n);
     }
 }
 
@@ -356,9 +356,9 @@ void dsp_addGreaterScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_REST
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_greaterScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_greaterScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_greaterScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_greaterScalar, src, f, dest, n);
     }
 }
 
@@ -370,9 +370,9 @@ void dsp_addLessPerformAliased (t_sample *src1, t_sample *src2, t_sample *dest, 
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_lessAliased, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_lessAliased, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_lessAliased, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_lessAliased, src1, src2, dest, n);
     }
 }
 
@@ -384,9 +384,9 @@ void dsp_addLessScalarPerform (PD_RESTRICTED src, t_float64Atomic *f, PD_RESTRIC
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_lessScalar, 4, src, f, dest, n); }
+    if (n & 7) { dsp_add4 (perform_lessScalar, src, f, dest, n); }
     else {
-        dsp_add (vPerform_lessScalar, 4, src, f, dest, n);
+        dsp_add4 (vPerform_lessScalar, src, f, dest, n);
     }
 }
 
@@ -400,9 +400,9 @@ void dsp_addMagnitudePerform (PD_RESTRICTED src1, PD_RESTRICTED src2, PD_RESTRIC
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_magnitude, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_magnitude, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_magnitude, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_magnitude, src1, src2, dest, n);
     }
 }
 
@@ -416,9 +416,9 @@ void dsp_addInverseMagnitudePerform (PD_RESTRICTED src1, PD_RESTRICTED src2, PD_
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (src2));
     PD_ASSERT (!PD_MALLOC_ALIGNED || PD_IS_ALIGNED_16 (dest));
     
-    if (n & 7) { dsp_add (perform_inverseMagnitude, 4, src1, src2, dest, n); }
+    if (n & 7) { dsp_add4 (perform_inverseMagnitude, src1, src2, dest, n); }
     else {
-        dsp_add (vPerform_inverseMagnitude, 4, src1, src2, dest, n);
+        dsp_add4 (vPerform_inverseMagnitude, src1, src2, dest, n);
     }
 }
 

--- a/src/dsp/graph/d_resample.c
+++ b/src/dsp/graph/d_resample.c
@@ -176,7 +176,7 @@ static void resample_addResampling (t_resample *x,
     //
     PD_ASSERT (!(inSize % outSize));
         
-    dsp_add (resample_performDownsampling, 4, in, out, inSize / outSize, inSize);
+    dsp_add4 (resample_performDownsampling, in, out, inSize / outSize, inSize);
     //
     } else {
     //
@@ -189,11 +189,11 @@ static void resample_addResampling (t_resample *x,
     case RESAMPLE_DEFAULT :
         PD_BUG;                 /* Falls through. */
     case RESAMPLE_ZERO    :
-        dsp_add (resample_performUpsamplingZero,    4, in, out, t, inSize); break;
+        dsp_add4 (resample_performUpsamplingZero,   in, out, t, inSize); break;
     case RESAMPLE_HOLD    :
-        dsp_add (resample_performUpsamplingHold,    4, in, out, t, inSize); break;
+        dsp_add4 (resample_performUpsamplingHold,   in, out, t, inSize); break;
     case RESAMPLE_LINEAR  :
-        dsp_add (resample_performUpsamplingLinear,  5, space_new (x->r_owner), in, out, t, inSize);
+        dsp_add5 (resample_performUpsamplingLinear, space_new (x->r_owner), in, out, t, inSize);
     //
     }
     //

--- a/src/dsp/graph/d_ugen.c
+++ b/src/dsp/graph/d_ugen.c
@@ -398,11 +398,11 @@ void ugen_graphClose (t_dspcontext *context)
     
     chainBegin = chain_getSize (instance_chainGetTemporary());
     
-    if (block && (p.bp_switchable || p.bp_reblocked)) { dsp_add (block_performPrologue, 2, block, c); }
+    if (block && (p.bp_switchable || p.bp_reblocked)) { dsp_add2 (block_performPrologue, block, c); }
 
     ugen_graphMain (context);
 
-    if (block && (p.bp_switchable || p.bp_reblocked)) { dsp_add (block_performEpilogue, 2, block, c); }
+    if (block && (p.bp_switchable || p.bp_reblocked)) { dsp_add2 (block_performEpilogue, block, c); }
     
     chainEnd = chain_getSize (instance_chainGetTemporary());
 

--- a/src/dsp/graph/d_vinlet.c
+++ b/src/dsp/graph/d_vinlet.c
@@ -162,7 +162,7 @@ void vinlet_dspPrologue (t_vinlet *x, t_signal **signals, t_blockproperties *p)
         c->s_in = resample_getBufferInlet (&x->vi_resample, s->s_vector, parentVectorSize, vectorSize);
     }
 
-    dsp_add (vinlet_performPrologue, 1, c);     /* Must be after resampling above. */
+    dsp_add1 (vinlet_performPrologue, c);       /* Must be after resampling above. */
     //
     }
     //
@@ -195,7 +195,7 @@ void vinlet_dsp (t_vinlet *x, t_signal **sp)
     //
     }
     
-    dsp_add (vinlet_perform, 3, c, out->s_vector, out->s_vectorSize);
+    dsp_add3 (vinlet_perform, c, out->s_vector, out->s_vectorSize);
     //
     }
     //

--- a/src/dsp/graph/d_voutlet.c
+++ b/src/dsp/graph/d_voutlet.c
@@ -132,7 +132,7 @@ void voutlet_dsp (t_voutlet *x, t_signal **sp)
     //
     }
         
-    dsp_add (voutlet_perform, 3, c, in->s_vector, in->s_vectorSize);        /* Reblocked. */
+    dsp_add3 (voutlet_perform, c, in->s_vector, in->s_vectorSize);      /* Reblocked. */
     //
     }
     //
@@ -187,7 +187,7 @@ void voutlet_dspEpilogue (t_voutlet *x, t_signal **signals, t_blockproperties *p
     
     if (signals) {
     //
-    dsp_add (voutlet_performEpilogue, 1, c);    /* Must be before resampling below. */
+    dsp_add1 (voutlet_performEpilogue, c);      /* Must be before resampling below. */
     
     c->s_outSize = vectorSize;
     c->s_out     = s->s_vector;

--- a/src/dsp/math/d_abs.c
+++ b/src/dsp/math/d_abs.c
@@ -50,7 +50,7 @@ static void abs_tilde_dsp (t_abs_tilde *x, t_signal **sp)
     
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (abs_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (abs_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_clip.c
+++ b/src/dsp/math/d_clip.c
@@ -89,7 +89,7 @@ static void clip_tilde_dsp (t_clip_tilde *x, t_signal **sp)
     
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (clip_tilde_perform, 4, x, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add4 (clip_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_dbtopow.c
+++ b/src/dsp/math/d_dbtopow.c
@@ -48,7 +48,7 @@ static void dbtopow_tilde_dsp (t_dbtopow_tilde *x, t_signal **sp)
 
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (dbtopow_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (dbtopow_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_dbtorms.c
+++ b/src/dsp/math/d_dbtorms.c
@@ -50,7 +50,7 @@ static void dbtorms_tilde_dsp (t_dbtorms_tilde *x, t_signal **sp)
 
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (dbtorms_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (dbtorms_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_exp.c
+++ b/src/dsp/math/d_exp.c
@@ -50,7 +50,7 @@ static void exp_tilde_dsp (t_exp_tilde *x, t_signal **sp)
 
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (exp_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (exp_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_ftom.c
+++ b/src/dsp/math/d_ftom.c
@@ -50,7 +50,7 @@ static void ftom_tilde_dsp (t_ftom_tilde *x, t_signal **sp)
 
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (ftom_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (ftom_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_log.c
+++ b/src/dsp/math/d_log.c
@@ -65,7 +65,7 @@ static void log_tilde_dsp (t_log_tilde *x, t_signal **sp)
     PD_ASSERT (sp[0]->s_vector != sp[2]->s_vector);
     PD_ASSERT (sp[1]->s_vector != sp[2]->s_vector);
     
-    dsp_add (log_tilde_perform, 4, sp[0]->s_vector, sp[1]->s_vector, sp[2]->s_vector, sp[0]->s_vectorSize);
+    dsp_add4 (log_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[2]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_mtof.c
+++ b/src/dsp/math/d_mtof.c
@@ -50,7 +50,7 @@ static void mtof_tilde_dsp (t_mtof_tilde *x, t_signal **sp)
     
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (mtof_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (mtof_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_pow.c
+++ b/src/dsp/math/d_pow.c
@@ -66,7 +66,7 @@ static void pow_tilde_dsp (t_pow_tilde *x, t_signal **sp)
     PD_ASSERT (sp[0]->s_vector != sp[2]->s_vector);
     PD_ASSERT (sp[1]->s_vector != sp[2]->s_vector);
     
-    dsp_add (pow_tilde_perform, 4, sp[0]->s_vector, sp[1]->s_vector, sp[2]->s_vector, sp[0]->s_vectorSize);
+    dsp_add4 (pow_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[2]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_powtodb.c
+++ b/src/dsp/math/d_powtodb.c
@@ -48,7 +48,7 @@ static void powtodb_tilde_dsp (t_powtodb_tilde *x, t_signal **sp)
 
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (powtodb_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (powtodb_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_rmstodb.c
+++ b/src/dsp/math/d_rmstodb.c
@@ -50,7 +50,7 @@ static void rmstodb_tilde_dsp (t_rmstodb_tilde *x, t_signal **sp)
 
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (rmstodb_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (rmstodb_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/math/d_wrap.c
+++ b/src/dsp/math/d_wrap.c
@@ -54,7 +54,7 @@ static void wrap_tilde_dsp (t_wrap_tilde *x, t_signal **sp)
     
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (wrap_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (wrap_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/miscellaneous/d_bang.c
+++ b/src/dsp/miscellaneous/d_bang.c
@@ -53,7 +53,7 @@ static t_int *bang_tilde_perform (t_int *w)
 
 static void bang_tilde_dsp (t_bang_tilde *x, t_signal **sp)
 {
-    dsp_add (bang_tilde_perform, 1, x);
+    dsp_add1 (bang_tilde_perform, x);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/miscellaneous/d_lrshift.c
+++ b/src/dsp/miscellaneous/d_lrshift.c
@@ -77,7 +77,7 @@ static void lrshift_tilde_dsp (t_lrshift_tilde *x, t_signal **sp)
     
     if (shift < 0) {
     
-        dsp_add (lrshift_tilde_peformShiftRight, 4, 
+        dsp_add4 (lrshift_tilde_peformShiftRight,
             sp[0]->s_vector + size,
             sp[1]->s_vector + size,
             size,
@@ -85,7 +85,7 @@ static void lrshift_tilde_dsp (t_lrshift_tilde *x, t_signal **sp)
             
     } else {
     
-        dsp_add (lrshift_tilde_peformShiftLeft, 4,
+        dsp_add4 (lrshift_tilde_peformShiftLeft,
             sp[0]->s_vector,
             sp[1]->s_vector,
             size,

--- a/src/dsp/miscellaneous/d_noise.c
+++ b/src/dsp/miscellaneous/d_noise.c
@@ -51,7 +51,7 @@ static t_int *noise_tilde_perform (t_int *w)
 
 static void noise_tilde_dsp (t_noise_tilde *x, t_signal **sp)
 {
-    dsp_add (noise_tilde_perform, 3, &x->x_state, sp[0]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (noise_tilde_perform, &x->x_state, sp[0]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/miscellaneous/d_print.c
+++ b/src/dsp/miscellaneous/d_print.c
@@ -95,7 +95,7 @@ static void print_tilde_dsp (t_print_tilde *x, t_signal **sp)
 {
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (print_tilde_perform, 3, x, sp[0]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (print_tilde_perform, x, sp[0]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/osc/d_cos.c
+++ b/src/dsp/osc/d_cos.c
@@ -114,7 +114,7 @@ static void cos_tilde_dsp (t_cos_tilde *x, t_signal **sp)
     
     object_fetchAndCopySignalValuesIfRequired (cast_object (x));
 
-    dsp_add (cos_tilde_perform, 3, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
+    dsp_add3 (cos_tilde_perform, sp[0]->s_vector, sp[1]->s_vector, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/osc/d_osc.c
+++ b/src/dsp/osc/d_osc.c
@@ -96,7 +96,7 @@ static void osc_tilde_dsp (t_osc_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (osc_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (osc_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/osc/d_phasor.c
+++ b/src/dsp/osc/d_phasor.c
@@ -87,7 +87,7 @@ static void phasor_tilde_dsp (t_phasor_tilde *x, t_signal **sp)
     //
     }
     
-    dsp_add (phasor_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (phasor_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/soundfile/d_readsf.c
+++ b/src/dsp/soundfile/d_readsf.c
@@ -228,7 +228,7 @@ static void readsf_tilde_dsp (t_readsf_tilde *x, t_signal **sp)
     
     for (i = 0; i < t->s_size; i++) { t->s_v[i] = sp[i]->s_vector; }
     
-    dsp_add (readsf_tilde_perform, 3, x, t, sp[0]->s_vectorSize);
+    dsp_add3 (readsf_tilde_perform, x, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/soundfile/d_writesf.c
+++ b/src/dsp/soundfile/d_writesf.c
@@ -200,7 +200,7 @@ static void writesf_tilde_dsp (t_writesf_tilde *x, t_signal **sp)
     
     for (i = 0; i < t->s_size; i++) { t->s_v[i] = sp[i]->s_vector; }
 
-    dsp_add (writesf_tilde_perform, 3, x, t, sp[0]->s_vectorSize);
+    dsp_add3 (writesf_tilde_perform, x, t, sp[0]->s_vectorSize);
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/dsp/tab/d_tabosc4.c
+++ b/src/dsp/tab/d_tabosc4.c
@@ -181,7 +181,7 @@ static void tabosc4_tilde_dsp (t_tabosc4_tilde *x, t_signal **sp)
     
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (tabosc4_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (tabosc4_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/tab/d_tabplay.c
+++ b/src/dsp/tab/d_tabplay.c
@@ -223,7 +223,7 @@ static void tabplay_tilde_dsp (t_tabplay_tilde *x, t_signal **sp)
     //
     }
 
-    dsp_add (tabplay_tilde_perform, 4, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add4 (tabplay_tilde_perform, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/tab/d_tabread.c
+++ b/src/dsp/tab/d_tabread.c
@@ -135,7 +135,7 @@ static void tabread_tilde_dsp (t_tabread_tilde *x, t_signal **sp)
 
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (tabread_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (tabread_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/tab/d_tabread4.c
+++ b/src/dsp/tab/d_tabread4.c
@@ -147,7 +147,7 @@ static void tabread4_tilde_dsp (t_tabread4_tilde *x, t_signal **sp)
 
     PD_ASSERT (sp[0]->s_vector != sp[1]->s_vector);
     
-    dsp_add (tabread4_tilde_perform, 5, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add5 (tabread4_tilde_perform, x, sp[0]->s_vector, sp[1]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/tab/d_tabreceive.c
+++ b/src/dsp/tab/d_tabreceive.c
@@ -129,7 +129,7 @@ static void tabreceive_tilde_dsp (t_tabreceive_tilde *x, t_signal **sp)
         t->s_int0 = size; t->s_pointer0 = (void *)w;
     }
     
-    dsp_add (tabreceive_tilde_perform, 4, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add4 (tabreceive_tilde_perform, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/tab/d_tabsend.c
+++ b/src/dsp/tab/d_tabsend.c
@@ -166,7 +166,7 @@ static void tabsend_tilde_dsp (t_tabsend_tilde *x, t_signal **sp)
         t->s_int0 = size; t->s_pointer0 = (void *)w;
     }
     
-    dsp_add (tabsend_tilde_perform, 4, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add4 (tabsend_tilde_perform, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/dsp/tab/d_tabwrite.c
+++ b/src/dsp/tab/d_tabwrite.c
@@ -268,7 +268,7 @@ static void tabwrite_tilde_dsp (t_tabwrite_tilde *x, t_signal **sp)
         tabwrite_tilde_space (t, w, size, PD_INT_MAX, 1);
     }
     
-    dsp_add (tabwrite_tilde_perform, 4, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
+    dsp_add4 (tabwrite_tilde_perform, x, sp[0]->s_vector, t, sp[0]->s_vectorSize);
     //
     }
 }

--- a/src/m_spaghettis.h
+++ b/src/m_spaghettis.h
@@ -769,7 +769,75 @@ typedef struct _signal {
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
-#define dsp_add(...)                    chain_append (instance_chainGetTemporary(), __VA_ARGS__)
+/* Deprecated. */
+
+#define dsp_add(...)                            chain_append (instance_chainGetTemporary(), __VA_ARGS__)
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+// MARK: -
+
+/* Use macros below. */
+
+#define dsp_add1(fn, a)                         chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 1, \
+                                                                (t_int)(a))
+
+#define dsp_add2(fn, a, b)                      chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 2, \
+                                                                (t_int)(a), \
+                                                                (t_int)(b))
+
+#define dsp_add3(fn, a, b, c)                   chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 3, \
+                                                                (t_int)(a), \
+                                                                (t_int)(b), \
+                                                                (t_int)(c))
+
+#define dsp_add4(fn, a, b, c, d)                chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 4, \
+                                                                (t_int)(a), \
+                                                                (t_int)(b), \
+                                                                (t_int)(c), \
+                                                                (t_int)(d))
+
+#define dsp_add5(fn, a, b, c, d, e)             chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 5, \
+                                                                (t_int)(a), \
+                                                                (t_int)(b), \
+                                                                (t_int)(c), \
+                                                                (t_int)(d), \
+                                                                (t_int)(e))
+
+#define dsp_add6(fn, a, b, c, d, e, f)          chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 6, \
+                                                                (t_int)(a), \
+                                                                (t_int)(b), \
+                                                                (t_int)(c), \
+                                                                (t_int)(d), \
+                                                                (t_int)(e), \
+                                                                (t_int)(f))
+
+#define dsp_add7(fn, a, b, c, d, e, f, g)       chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 7, \
+                                                                (t_int)(a), \
+                                                                (t_int)(b), \
+                                                                (t_int)(c), \
+                                                                (t_int)(d), \
+                                                                (t_int)(e), \
+                                                                (t_int)(f), \
+                                                                (t_int)(g))
+
+#define dsp_add8(fn, a, b, c, d, e, f, g, h)    chain_append (instance_chainGetTemporary(), \
+                                                                (t_perform)(fn), 8, \
+                                                                (t_int)(a), \
+                                                                (t_int)(b), \
+                                                                (t_int)(c), \
+                                                                (t_int)(d), \
+                                                                (t_int)(e), \
+                                                                (t_int)(f), \
+                                                                (t_int)(g), \
+                                                                (t_int)(h))
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Proposed changes**
 
  - Use more explicit macros instead of dsp_add.
  - Do that to avoid weird errors in the future with wrong type casting (due to variadic function).
  - For instance: < https://github.com/pure-data/pure-data/pull/673 >.
  - Specially in order to support more platforms easily.
