### PR TITLE
Set FTZ flag for ARM NEON

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@
 
 Platforms:
 
-    Tested on Ubuntu 18.04, macOS 10.14, and Raspbian (RPI4).
+    Tested on Ubuntu 18.04, macOS 10.14, and Raspbian Buster (RPI4).
     
 Dependencies:
 

--- a/src/system/s_denormal.c
+++ b/src/system/s_denormal.c
@@ -28,11 +28,38 @@ void denormal_setPolicy (void)
     _MM_SET_FLUSH_ZERO_MODE (_MM_FLUSH_ZERO_ON);
 }
 
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+
+/* < https://www.raspberrypi.org/forums/viewtopic.php?t=148600 > */
+
+#elif defined ( PD_ARM ) && defined ( __ARM_NEON )
+
+/* Stolen from JUCE (FloatVectorOperations::enableFlushToZeroMode). */
+
+static intptr_t denormal_getFPSR (void)
+{
+    intptr_t fpsr = 0; asm volatile("vmrs %0, fpscr" : "=r" (fpsr)); return fpsr;       // --
+}
+
+static void denormal_setFPSR (intptr_t fpsr)
+{
+    asm volatile("vmsr fpscr, %0" : : "ri" (fpsr));                                     // --
+}
+
+void denormal_setPolicy (void)
+{
+    denormal_setFPSR ((denormal_getFPSR() | (intptr_t)(1 << 24)));
+}
+
+// -----------------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
+
 #else
 
 void denormal_setPolicy (void)
 {
-    // -- TODO: Manage ARM case (RPI for instance).
+
 }
 
 #endif


### PR DESCRIPTION

**Proposed changes**
 
  - Add FTZ flag to avoid denormal numbers with ARM NEON (RPI4).

See: #206
See: #209