### PR TITLE
Update to Catalina

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@
 
 Platforms:
 
-    Tested on Ubuntu 18.04, macOS 10.14, and Raspbian Buster (RPI4).
+    Tested on Ubuntu 18.04, macOS 10.15, and Raspbian Buster (RPI4).
     
 Dependencies:
 


### PR DESCRIPTION
Fixes #198 

Tested on macOS Catalina.

- Reported into the console:
```
HALPlugInManagement::RegisterPlugIns: skipping in-process plug-ins
AddInstanceForFactory: No factory registered for id
HALC_ShellDriverPlugIn::Open: Can't get a pointer to the Open routine
HALC_ShellDriverPlugIn::Open: Can't get a pointer to the Open routine
```

- As usual:

`exceeding limit of 150 wakeups per second over 300 seconds`

 - Open file dialog seems slow, but i guess this (Wish) will be fix later. 
