### PR TITLE
Fix gcc warning

### DIFF
--- a/libraries/T/T.c
+++ b/libraries/T/T.c
@@ -17,7 +17,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/shm.h>
-#include <sys/sysctl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -28,6 +27,7 @@
 #if TTT_APPLE
     #include <mach/mach.h>
     #include <mach/mach_time.h>
+    #include <sys/sysctl.h>
 #endif
 
 #if TTT_LINUX


### PR DESCRIPTION
Fix a gcc warning (9.2 version) building tests on Manjaro Linux.
