### PR TITLE
Remove IEM compatibility with legacy

### DIFF
--- a/src/control/text/x_text.c
+++ b/src/control/text/x_text.c
@@ -74,7 +74,7 @@ void textdefine_append (t_textdefine *x, t_symbol *s, int argc, t_atom *argv)
 
 static void textdefine_modified (t_textdefine *x)
 {
-    outlet_symbol (x->x_outlet, sym_updated);
+    outlet_bang (x->x_outlet);
 }
 
 // -----------------------------------------------------------------------------------------------------------
@@ -157,7 +157,7 @@ static void *textdefine_new (t_symbol *s, int argc, t_atom *argv)
     
     if (argc) { warning_unusedArguments (s, argc, argv); }
     
-    x->x_outlet = outlet_newSymbol (cast_object (x));
+    x->x_outlet = outlet_newBang (cast_object (x));
     
     return x;
 }

--- a/src/control/text/x_textfile.c
+++ b/src/control/text/x_textfile.c
@@ -72,7 +72,7 @@ static void *textfile_new (t_symbol *s, int argc, t_atom *argv)
     
     x->ql_indexOfMessage = 0;
     x->ql_owner          = instance_contextGetCurrent();
-    x->ql_outletLeft     = outlet_newList (cast_object (x));
+    x->ql_outletLeft     = outlet_newMixed (cast_object (x));
     x->ql_outletMiddle   = outlet_newBang (cast_object (x));
     x->ql_outletRight    = outlet_newBang (cast_object (x));
     

--- a/src/core/m_symbols.c
+++ b/src/core/m_symbols.c
@@ -769,7 +769,6 @@ t_symbol *sym_undotyping;
 t_symbol *sym_unit;
 t_symbol *sym_unpack;
 t_symbol *sym_until;
-t_symbol *sym_updated;
 t_symbol *sym_urn;
 t_symbol *sym_uzi;
 t_symbol *sym_v;
@@ -1550,7 +1549,6 @@ void symbols_initialize (void)
     sym_unit                                    = gensym ("unit");
     sym_unpack                                  = gensym ("unpack");
     sym_until                                   = gensym ("until");
-    sym_updated                                 = gensym ("updated");
     sym_urn                                     = gensym ("urn");
     sym_uzi                                     = gensym ("uzi");
     sym_v                                       = gensym ("v");

--- a/src/core/m_symbols.h
+++ b/src/core/m_symbols.h
@@ -769,7 +769,6 @@ extern t_symbol *sym_undotyping;
 extern t_symbol *sym_unit;
 extern t_symbol *sym_unpack;
 extern t_symbol *sym_until;
-extern t_symbol *sym_updated;
 extern t_symbol *sym_urn;
 extern t_symbol *sym_uzi;
 extern t_symbol *sym_v;

--- a/src/core/m_utils.h
+++ b/src/core/m_utils.h
@@ -156,7 +156,6 @@ static inline int string_startWithOneDollarAndOneNumber (const char *s)
 
 #define COLOR_IEM_BACKGROUND        0xffffff    // White.
 #define COLOR_IEM_FOREGROUND        0x000000    // Black.
-#define COLOR_IEM_LABEL             0x000000    // Black.
 #define COLOR_IEM_PANEL             0xcccccc    // Grey.
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/graphics/iem/g_bang.c
+++ b/src/graphics/iem/g_bang.c
@@ -25,7 +25,6 @@
 // -----------------------------------------------------------------------------------------------------------
 
 #define IEM_BANG_DEFAULT_HOLD       250
-#define IEM_BANG_DEFAULT_BREAK      50
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
@@ -333,18 +332,18 @@ static void bng_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendSymbol (b, sym_bng);
     buffer_appendFloat (b,  x->x_gui.iem_width);
     buffer_appendFloat (b,  x->x_flashTime);
-    buffer_appendFloat (b,  x->x_flashTimeBreak);
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
     buffer_appendFloat (b,  iemgui_serializeLoadbang (cast_iem (z)));
     buffer_appendSymbol (b, names.n_unexpandedSend);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
-    buffer_appendFloat (b,  x->x_gui.iem_labelX);
-    buffer_appendFloat (b,  x->x_gui.iem_labelY);
-    buffer_appendFloat (b,  iemgui_serializeFontStyle (cast_iem (z)));
-    buffer_appendFloat (b,  x->x_gui.iem_fontSize);
+    buffer_appendSymbol (b, symbol_nil());                      /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
     buffer_appendSymbol (b, colors.c_symColorForeground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
+    buffer_appendSymbol (b, color_toEncoded (0));               /* Legacy. */
     buffer_appendSemicolon (b);
     
     gobj_saveUniques (z, b, flags);
@@ -459,27 +458,18 @@ static void *bng_new (t_symbol *s, int argc, t_atom *argv)
 {
     t_bng *x = (t_bng *)pd_new (bng_class);
     
-    int size            = IEM_DEFAULT_SIZE;
-    int flashHold       = IEM_BANG_DEFAULT_HOLD;
-    int flashBreak      = IEM_BANG_DEFAULT_BREAK;
-    int labelX          = 0;
-    int labelY          = 0;
-    int labelFontSize   = IEM_DEFAULT_FONT;
+    int size        = IEM_DEFAULT_SIZE;
+    int flashHold   = IEM_BANG_DEFAULT_HOLD;
     
     if (argc != 14) { iemgui_deserializeDefault (cast_iem (x)); }
     else {
     //
     size            = (int)atom_getFloatAtIndex (0,  argc, argv);
     flashHold       = (int)atom_getFloatAtIndex (1,  argc, argv);
-    flashBreak      = (int)atom_getFloatAtIndex (2,  argc, argv);
-    labelX          = (int)atom_getFloatAtIndex (7,  argc, argv);
-    labelY          = (int)atom_getFloatAtIndex (8,  argc, argv);
-    labelFontSize   = (int)atom_getFloatAtIndex (10, argc, argv);
     
     iemgui_deserializeLoadbang (cast_iem (x), (int)atom_getFloatAtIndex (3, argc, argv));
     iemgui_deserializeNames (cast_iem (x), 4, argv);
-    iemgui_deserializeFontStyle (cast_iem (x), (int)atom_getFloatAtIndex (9, argc, argv));
-    iemgui_deserializeColors (cast_iem (x), argv + 11, argv + 12, argv + 13);
+    iemgui_deserializeColors (cast_iem (x), argv + 11, argv + 12);
     //
     }
 
@@ -489,15 +479,11 @@ static void *bng_new (t_symbol *s, int argc, t_atom *argv)
     x->x_gui.iem_canReceive = symbol_isNil (x->x_gui.iem_receive) ? 0 : 1;
     x->x_gui.iem_width      = PD_MAX (size, IEM_MINIMUM_WIDTH);
     x->x_gui.iem_height     = PD_MAX (size, IEM_MINIMUM_WIDTH);
-    x->x_gui.iem_labelX     = labelX;
-    x->x_gui.iem_labelY     = labelY;
-    x->x_gui.iem_fontSize   = labelFontSize;
     
     iemgui_checkSendReceiveLoop (cast_iem (x));
     
     if (x->x_gui.iem_canReceive) { pd_bind (cast_pd (x), x->x_gui.iem_receive); }
     
-    x->x_flashTimeBreak     = flashBreak;
     x->x_flashTime          = PD_MAX (flashHold, IEM_BANG_MINIMUM_HOLD);
     
     x->x_outlet = outlet_newBang (cast_object (x));

--- a/src/graphics/iem/g_dial.c
+++ b/src/graphics/iem/g_dial.c
@@ -25,6 +25,7 @@
 // -----------------------------------------------------------------------------------------------------------
 
 #define IEM_DIAL_DEFAULT_DIGITS         5
+#define IEM_DIAL_DEFAULT_FONT           10
 #define IEM_DIAL_DEFAULT_STEPS          127
 #define IEM_DIAL_DEFAULT_SIZE           40
 #define IEM_DIAL_DEFAULT_MINIMUM        0
@@ -604,14 +605,14 @@ static void dial_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  iemgui_serializeLoadbang (cast_iem (z)));
     buffer_appendSymbol (b, names.n_unexpandedSend);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
-    buffer_appendFloat (b,  x->x_gui.iem_labelX);
-    buffer_appendFloat (b,  x->x_gui.iem_labelY);
-    buffer_appendFloat (b,  iemgui_serializeFontStyle (cast_iem (z)));
-    buffer_appendFloat (b,  x->x_gui.iem_fontSize);
+    buffer_appendSymbol (b, symbol_nil());                  /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
     buffer_appendSymbol (b, colors.c_symColorForeground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
+    buffer_appendSymbol (b, color_toEncoded (0));           /* Legacy. */
     buffer_appendFloat (b,  x->x_floatValue);
     buffer_appendFloat (b,  x->x_steps);
     if (SAVED_DEEP (flags)) { buffer_appendFloat (b, 1.0); }
@@ -781,9 +782,6 @@ static void *dial_new (t_symbol *s, int argc, t_atom *argv)
     int digits          = IEM_DIAL_DEFAULT_DIGITS;
     int height          = IEM_DIAL_DEFAULT_SIZE;
     int isLogarithmic   = 0;
-    int labelX          = 0;
-    int labelY          = 0;
-    int labelFontSize   = IEM_DEFAULT_FONT;
     int steps           = IEM_DIAL_DEFAULT_STEPS;
     double minimum      = IEM_DIAL_DEFAULT_MINIMUM;
     double maximum      = IEM_DIAL_DEFAULT_MAXIMUM;
@@ -798,9 +796,6 @@ static void *dial_new (t_symbol *s, int argc, t_atom *argv)
     minimum         = (double)atom_getFloatAtIndex (2, argc, argv);
     maximum         = (double)atom_getFloatAtIndex (3, argc, argv);
     isLogarithmic   = (int)atom_getFloatAtIndex (4,  argc, argv);
-    labelX          = (int)atom_getFloatAtIndex (9,  argc, argv);
-    labelY          = (int)atom_getFloatAtIndex (10, argc, argv);
-    labelFontSize   = (int)atom_getFloatAtIndex (12, argc, argv);
     value           = atom_getFloatAtIndex (16, argc, argv);
     deep            = (argc > 18);
     
@@ -808,8 +803,7 @@ static void *dial_new (t_symbol *s, int argc, t_atom *argv)
 
     iemgui_deserializeLoadbang (cast_iem (x), (int)atom_getFloatAtIndex (5, argc, argv));
     iemgui_deserializeNames (cast_iem (x), 6, argv);
-    iemgui_deserializeFontStyle (cast_iem (x), (int)atom_getFloatAtIndex (11, argc, argv));
-    iemgui_deserializeColors (cast_iem (x), argv + 13, argv + 14, argv + 15);
+    iemgui_deserializeColors (cast_iem (x), argv + 13, argv + 14);
     //
     }
     
@@ -819,11 +813,8 @@ static void *dial_new (t_symbol *s, int argc, t_atom *argv)
     x->x_gui.iem_canReceive = symbol_isNil (x->x_gui.iem_receive) ? 0 : 1;
     x->x_gui.iem_width      = 0;
     x->x_gui.iem_height     = PD_MAX (height, IEM_MINIMUM_WIDTH);
-    x->x_gui.iem_labelX     = labelX;
-    x->x_gui.iem_labelY     = labelY;
-    x->x_gui.iem_fontSize   = labelFontSize;
     x->x_hasKnob            = -1;
-    x->x_digitsFontSize     = IEM_DEFAULT_FONT;
+    x->x_digitsFontSize     = IEM_DIAL_DEFAULT_FONT;
     
     iemgui_checkSendReceiveLoop (cast_iem (x));
     

--- a/src/graphics/iem/g_iem.h
+++ b/src/graphics/iem/g_iem.h
@@ -28,7 +28,6 @@
 // MARK: -
 
 #define IEM_DEFAULT_SIZE                15
-#define IEM_DEFAULT_FONT                10
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
@@ -61,13 +60,11 @@
 typedef struct _iemcolors {
     t_symbol        *c_symColorBackground;
     t_symbol        *c_symColorForeground;
-    t_symbol        *c_symColorLabel;               /* Unused but kept for compatibility. */
     } t_iemcolors;
 
 typedef struct _iemnames {
     t_symbol        *n_unexpandedSend;
     t_symbol        *n_unexpandedReceive;
-    t_symbol        *n_unexpandedLabel;             /* Unused but kept for compatibility. */
     } t_iemnames;
     
 // -----------------------------------------------------------------------------------------------------------
@@ -83,7 +80,6 @@ typedef struct _iem {
     t_object        iem_obj;                        /* MUST be the first. */
     t_glist         *iem_owner;
     t_iemfn         iem_fnDraw;
-    int             iem_fontStyle;                  /* Unused but kept for compatibility. */
     int             iem_canSend;
     int             iem_canReceive;
     int             iem_loadbang;
@@ -91,19 +87,13 @@ typedef struct _iem {
     int             iem_goThrough;
     int             iem_width;
     int             iem_height;
-    int             iem_labelX;                     /* Unused but kept for compatibility. */
-    int             iem_labelY;                     /* Unused but kept for compatibility. */
-    int             iem_fontSize;                   /* Unused but kept for compatibility. */
     t_color         iem_colorBackground;
     t_color         iem_colorForeground;
-    t_color         iem_colorLabel;                 /* Unused but kept for compatibility. */
     int             iem_cacheIndex;
     t_symbol        *iem_send;
     t_symbol        *iem_receive;
-    t_symbol        *iem_label;                     /* Unused but kept for compatibility. */
     t_symbol        *iem_unexpandedSend;
     t_symbol        *iem_unexpandedReceive;
-    t_symbol        *iem_unexpandedLabel;           /* Unused but kept for compatibility. */
     } t_iem;
 
 // -----------------------------------------------------------------------------------------------------------
@@ -113,7 +103,6 @@ typedef struct _iem {
 typedef struct _bng {
     t_iem           x_gui;                          /* MUST be the first. */
     int             x_flashed;
-    int             x_flashTimeBreak;               /* Unused but kept for compatibility. */
     int             x_flashTime;
     t_outlet        *x_outlet;
     t_clock         *x_clock;
@@ -129,7 +118,6 @@ typedef struct _toggle {
 typedef struct _radio {
     t_iem           x_gui;
     int             x_isVertical;
-    int             x_changed;                      /* Unused but kept for compatibility. */
     int             x_numberOfButtons;
     int64_t         x_state;
     t_float         x_floatValue;
@@ -166,7 +154,6 @@ typedef struct _dial {
     
 typedef struct _vu {
     t_iem           x_gui;
-    int             x_hasScale;                     /* Unused but kept for compatibility. */
     int             x_thickness;
     int             x_peak;
     int             x_decibel;
@@ -178,7 +165,6 @@ typedef struct _vu {
 
 typedef struct _panel {
     t_iem           x_gui;
-    t_atom          x_t[2];
     int             x_panelWidth;
     int             x_panelHeight;
     } t_panel;
@@ -201,12 +187,10 @@ typedef struct _menubutton {
 // MARK: -
 
 void    iemgui_serializeColors              (t_iem *iem, t_iemcolors *c);
-int     iemgui_serializeFontStyle           (t_iem *iem);
 int     iemgui_serializeLoadbang            (t_iem *iem);
 void    iemgui_serializeNames               (t_iem *iem, t_iemnames *n);
 
-void    iemgui_deserializeColors            (t_iem *iem, t_atom *bgrd, t_atom *fgrd, t_atom *label);
-void    iemgui_deserializeFontStyle         (t_iem *iem, int n);
+void    iemgui_deserializeColors            (t_iem *iem, t_atom *bgrd, t_atom *fgrd);
 void    iemgui_deserializeLoadbang          (t_iem *iem, int n);
 void    iemgui_deserializeNames             (t_iem *iem, int i, t_atom *argv);
 
@@ -239,8 +223,8 @@ void    iemgui_dirty                        (t_iem *iem, int isDirty, int isUndo
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
 
-t_buffer    *iemgui_functionData                (t_gobj *z, int flags);
-void        iemgui_restore                      (t_gobj *x, t_gobj *old);
+t_buffer    *iemgui_functionData            (t_gobj *z, int flags);
+void        iemgui_restore                  (t_gobj *x, t_gobj *old);
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------

--- a/src/graphics/iem/g_menubutton.c
+++ b/src/graphics/iem/g_menubutton.c
@@ -477,10 +477,10 @@ static void menubutton_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  iemgui_serializeLoadbang (cast_iem (z)));
     buffer_appendSymbol (b, names.n_unexpandedSend);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
+    buffer_appendSymbol (b, symbol_nil());                          /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
     buffer_appendSymbol (b, colors.c_symColorForeground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
+    buffer_appendSymbol (b, color_toEncoded (0));                   /* Legacy. */
     buffer_appendFloat (b,  (SAVED_DEEP (flags) || x->x_gui.iem_loadbang) ? x->x_index : 0.0);
     buffer_appendSemicolon (b);
     
@@ -677,7 +677,7 @@ static void *menubutton_new (t_symbol *s, int argc, t_atom *argv)
     
     iemgui_deserializeLoadbang (cast_iem (x), (int)atom_getFloatAtIndex (3, argc, argv));
     iemgui_deserializeNames (cast_iem (x), 4, argv);
-    iemgui_deserializeColors (cast_iem (x), argv + 7, argv + 8, argv + 9);
+    iemgui_deserializeColors (cast_iem (x), argv + 7, argv + 8);
     //
     }
     

--- a/src/graphics/iem/g_panel.c
+++ b/src/graphics/iem/g_panel.c
@@ -24,11 +24,6 @@
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
 
-/* Note that the grip size has been kept for compatibility with legacy patches only. */
-
-// -----------------------------------------------------------------------------------------------------------
-// -----------------------------------------------------------------------------------------------------------
-
 #define IEM_PANEL_DEFAULT_WIDTH     275
 #define IEM_PANEL_DEFAULT_HEIGHT    45
 
@@ -223,18 +218,18 @@ static void panel_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  object_getX (cast_object (z)));
     buffer_appendFloat (b,  object_getY (cast_object (z)));
     buffer_appendSymbol (b, sym_cnv);
-    buffer_appendFloat (b,  x->x_gui.iem_width);
+    buffer_appendFloat (b,  IEM_DEFAULT_SIZE);                  /* Legacy. */
     buffer_appendFloat (b,  x->x_panelWidth);
     buffer_appendFloat (b,  x->x_panelHeight);
     buffer_appendSymbol (b, names.n_unexpandedSend);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
-    buffer_appendFloat (b,  x->x_gui.iem_labelX);
-    buffer_appendFloat (b,  x->x_gui.iem_labelY);
-    buffer_appendFloat (b,  iemgui_serializeFontStyle (cast_iem (z)));
-    buffer_appendFloat (b,  x->x_gui.iem_fontSize);
+    buffer_appendSymbol (b, symbol_nil());                      /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
+    buffer_appendSymbol (b, color_toEncoded (0));               /* Legacy. */
     buffer_appendSemicolon (b);
     
     gobj_saveUniques (z, b, flags);
@@ -347,26 +342,17 @@ static void *panel_new (t_symbol *s, int argc, t_atom *argv)
 {
     t_panel *x = (t_panel *)pd_new (panel_class);
     
-    int gripSize        = IEM_DEFAULT_SIZE;
-    int panelWidth      = IEM_PANEL_DEFAULT_WIDTH;
-    int panelHeight     = IEM_PANEL_DEFAULT_HEIGHT;
-    int labelX          = 0;
-    int labelY          = 0;
-    int labelFontSize   = IEM_DEFAULT_FONT;
+    int panelWidth  = IEM_PANEL_DEFAULT_WIDTH;
+    int panelHeight = IEM_PANEL_DEFAULT_HEIGHT;
         
     if (argc < 12) { iemgui_deserializeDefault (cast_iem (x)); }
     else {
     //
-    gripSize        = (int)atom_getFloatAtIndex (0, argc, argv);
     panelWidth      = (int)atom_getFloatAtIndex (1, argc, argv);
     panelHeight     = (int)atom_getFloatAtIndex (2, argc, argv);
-    labelX          = (int)atom_getFloatAtIndex (6, argc, argv);
-    labelY          = (int)atom_getFloatAtIndex (7, argc, argv);
-    labelFontSize   = (int)atom_getFloatAtIndex (9, argc, argv);
     
     iemgui_deserializeNames (cast_iem (x), 3, argv);
-    iemgui_deserializeFontStyle (cast_iem (x), (int)atom_getFloatAtIndex (8, argc, argv));
-    iemgui_deserializeColors (cast_iem (x), argv + 10, NULL, argv + 11);
+    iemgui_deserializeColors (cast_iem (x), argv + 10, NULL);
     //
     }
     
@@ -375,12 +361,6 @@ static void *panel_new (t_symbol *s, int argc, t_atom *argv)
     x->x_gui.iem_canSend    = symbol_isNil (x->x_gui.iem_send) ? 0 : 1;
     x->x_gui.iem_canReceive = symbol_isNil (x->x_gui.iem_receive) ? 0 : 1;
 
-    x->x_gui.iem_width      = PD_MAX (gripSize, IEM_PANEL_MINIMUM_SIZE);
-    x->x_gui.iem_height     = PD_MAX (gripSize, IEM_PANEL_MINIMUM_SIZE);
-    x->x_gui.iem_labelX     = labelX;
-    x->x_gui.iem_labelY     = labelY;
-    x->x_gui.iem_fontSize   = labelFontSize;
-    
     iemgui_checkSendReceiveLoop (cast_iem (x));
     
     if (x->x_gui.iem_canReceive) { pd_bind (cast_pd (x), x->x_gui.iem_receive); }
@@ -388,9 +368,6 @@ static void *panel_new (t_symbol *s, int argc, t_atom *argv)
     x->x_panelWidth  = PD_MAX (panelWidth,  IEM_PANEL_MINIMUM_SIZE);
     x->x_panelHeight = PD_MAX (panelHeight, IEM_PANEL_MINIMUM_SIZE);
 
-    SET_FLOAT (&x->x_t[0], 0.0);
-    SET_FLOAT (&x->x_t[1], 0.0);
-    
     return x;
 }
 

--- a/src/graphics/iem/g_radio.c
+++ b/src/graphics/iem/g_radio.c
@@ -522,20 +522,20 @@ static void radio_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  x->x_gui.iem_width);
     if (x->x_mode == sym_multiple) { buffer_appendSymbol (b, x->x_mode); }
     else {
-        buffer_appendFloat (b,  x->x_changed);
+        buffer_appendFloat (b, 1);                          /* Legacy. */
     }
     buffer_appendFloat (b,  iemgui_serializeLoadbang (cast_iem (z)));
     buffer_appendFloat (b,  x->x_numberOfButtons);
     buffer_appendSymbol (b, names.n_unexpandedSend);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
-    buffer_appendFloat (b,  x->x_gui.iem_labelX);
-    buffer_appendFloat (b,  x->x_gui.iem_labelY);
-    buffer_appendFloat (b,  iemgui_serializeFontStyle (cast_iem (z)));
-    buffer_appendFloat (b,  x->x_gui.iem_fontSize);
+    buffer_appendSymbol (b, symbol_nil());                  /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
     buffer_appendSymbol (b, colors.c_symColorForeground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
+    buffer_appendSymbol (b, color_toEncoded (0));           /* Legacy. */
     buffer_appendFloat (b,  x->x_floatValue);
     if (SAVED_DEEP (flags)) { buffer_appendFloat (b, 1.0); }
     buffer_appendSemicolon (b);
@@ -698,10 +698,6 @@ static void *radio_new (t_symbol *s, int argc, t_atom *argv)
     {
     //
     int size            = IEM_DEFAULT_SIZE;
-    int labelX          = 0;
-    int labelY          = 0;
-    int labelFontSize   = IEM_DEFAULT_FONT;
-    int changed         = 1;
     int numberOfButtons = IEM_RADIO_BUTTONS_DEFAULT;
     t_float floatValue  = 0.0;
     t_symbol *mode      = NULL;
@@ -711,19 +707,14 @@ static void *radio_new (t_symbol *s, int argc, t_atom *argv)
     else {
     //
     size            = (int)atom_getFloatAtIndex (0, argc,  argv);
-    changed         = (int)atom_getFloatAtIndex (1, argc,  argv);
     numberOfButtons = (int)atom_getFloatAtIndex (3, argc,  argv);
-    labelX          = (int)atom_getFloatAtIndex (7, argc,  argv);
-    labelY          = (int)atom_getFloatAtIndex (8, argc,  argv);
-    labelFontSize   = (int)atom_getFloatAtIndex (10, argc, argv);
     floatValue      = atom_getFloatAtIndex (14, argc, argv);
     mode            = atom_getSymbolAtIndex (1, argc, argv);
     deep            = (argc > 15);
     
     iemgui_deserializeLoadbang (cast_iem (x), (int)atom_getFloatAtIndex (2, argc, argv));
     iemgui_deserializeNames (cast_iem (x), 4, argv);
-    iemgui_deserializeFontStyle (cast_iem (x), (int)atom_getFloatAtIndex (9, argc, argv));
-    iemgui_deserializeColors (cast_iem (x), argv + 11, argv + 12, argv + 13);
+    iemgui_deserializeColors (cast_iem (x), argv + 11, argv + 12);
     //
     }
     
@@ -733,15 +724,11 @@ static void *radio_new (t_symbol *s, int argc, t_atom *argv)
     x->x_gui.iem_canReceive = symbol_isNil (x->x_gui.iem_receive) ? 0 : 1;
     x->x_gui.iem_width      = PD_MAX (size, IEM_MINIMUM_WIDTH);
     x->x_gui.iem_height     = PD_MAX (size, IEM_MINIMUM_WIDTH);
-    x->x_gui.iem_labelX     = labelX;
-    x->x_gui.iem_labelY     = labelY;
-    x->x_gui.iem_fontSize   = labelFontSize;
     
     iemgui_checkSendReceiveLoop (cast_iem (x));
     
     if (x->x_gui.iem_canReceive) { pd_bind (cast_pd (x), x->x_gui.iem_receive); }
         
-    x->x_changed = (changed != 0);
     x->x_numberOfButtons = PD_CLAMP (numberOfButtons, 1, IEM_RADIO_BUTTONS_MAXIMUM);
     x->x_floatValue = (deep || x->x_gui.iem_loadbang) ? floatValue : 0;
     x->x_mode = (mode == sym_multiple) ? sym_multiple : sym_single;

--- a/src/graphics/iem/g_slider.c
+++ b/src/graphics/iem/g_slider.c
@@ -555,14 +555,14 @@ static void slider_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  iemgui_serializeLoadbang (cast_iem (z)));
     buffer_appendSymbol (b, names.n_unexpandedSend);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
-    buffer_appendFloat (b,  x->x_gui.iem_labelX);
-    buffer_appendFloat (b,  x->x_gui.iem_labelY);
-    buffer_appendFloat (b,  iemgui_serializeFontStyle (cast_iem (z)));
-    buffer_appendFloat (b,  x->x_gui.iem_fontSize);
+    buffer_appendSymbol (b, symbol_nil());                  /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
+    buffer_appendFloat (b,  0);                             /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
     buffer_appendSymbol (b, colors.c_symColorForeground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
+    buffer_appendSymbol (b, color_toEncoded (0));           /* Legacy. */
     buffer_appendFloat (b,  x->x_position);
     buffer_appendFloat (b,  x->x_isSteadyOnClick);
     if (SAVED_DEEP (flags)) { buffer_appendFloat (b, 1.0); }
@@ -736,10 +736,7 @@ static void *slider_new (t_symbol *s, int argc, t_atom *argv)
     int width           = x->x_isVertical ? IEM_VSLIDER_DEFAULT_WIDTH  : IEM_HSLIDER_DEFAULT_WIDTH;
     int height          = x->x_isVertical ? IEM_VSLIDER_DEFAULT_HEIGHT : IEM_HSLIDER_DEFAULT_HEIGHT;
     int isLogarithmic   = 0;
-    int labelX          = 0;
-    int labelY          = 0;
     int isSteady        = 0;
-    int labelFontSize   = IEM_DEFAULT_FONT;
     double minimum      = 0.0;
     double maximum      = (double)(x->x_isVertical ? (height - 1) : (width - 1));
     t_float position    = 0.0;
@@ -753,9 +750,6 @@ static void *slider_new (t_symbol *s, int argc, t_atom *argv)
     minimum         = (double)atom_getFloatAtIndex (2, argc, argv);
     maximum         = (double)atom_getFloatAtIndex (3, argc, argv);
     isLogarithmic   = (int)atom_getFloatAtIndex (4,  argc, argv);
-    labelX          = (int)atom_getFloatAtIndex (9,  argc, argv);
-    labelY          = (int)atom_getFloatAtIndex (10, argc, argv);
-    labelFontSize   = (int)atom_getFloatAtIndex (12, argc, argv);
     position        = atom_getFloatAtIndex (16, argc, argv);
     deep            = (argc > 18);
     
@@ -763,8 +757,7 @@ static void *slider_new (t_symbol *s, int argc, t_atom *argv)
     
     iemgui_deserializeLoadbang (cast_iem (x), (int)atom_getFloatAtIndex (5, argc, argv));
     iemgui_deserializeNames (cast_iem (x), 6, argv);
-    iemgui_deserializeFontStyle (cast_iem (x), (int)atom_getFloatAtIndex (11, argc, argv));
-    iemgui_deserializeColors (cast_iem (x), argv + 13, argv + 14, argv + 15);
+    iemgui_deserializeColors (cast_iem (x), argv + 13, argv + 14);
     //
     }
     
@@ -772,9 +765,6 @@ static void *slider_new (t_symbol *s, int argc, t_atom *argv)
     x->x_gui.iem_fnDraw     = (t_iemfn)slider_draw;
     x->x_gui.iem_canSend    = symbol_isNil (x->x_gui.iem_send) ? 0 : 1;
     x->x_gui.iem_canReceive = symbol_isNil (x->x_gui.iem_receive) ? 0 : 1;
-    x->x_gui.iem_labelX     = labelX;
-    x->x_gui.iem_labelY     = labelY;
-    x->x_gui.iem_fontSize   = labelFontSize;
 
     slider_setHeight (x, height);
     slider_setWidth (x, width);

--- a/src/graphics/iem/g_toggle.c
+++ b/src/graphics/iem/g_toggle.c
@@ -328,14 +328,14 @@ static void toggle_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  iemgui_serializeLoadbang (cast_iem (z)));
     buffer_appendSymbol (b, names.n_unexpandedSend);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
-    buffer_appendFloat (b,  x->x_gui.iem_labelX);
-    buffer_appendFloat (b,  x->x_gui.iem_labelY);
-    buffer_appendFloat (b,  iemgui_serializeFontStyle (cast_iem (z)));
-    buffer_appendFloat (b,  x->x_gui.iem_fontSize);
+    buffer_appendSymbol (b, symbol_nil());                      /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
     buffer_appendSymbol (b, colors.c_symColorForeground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
+    buffer_appendSymbol (b, color_toEncoded (0));               /* Legacy. */
     buffer_appendFloat (b,  x->x_state);
     buffer_appendFloat (b,  x->x_nonZero);
     if (SAVED_DEEP (flags)) { buffer_appendFloat (b, 1.0); }
@@ -466,29 +466,22 @@ static void *toggle_new (t_symbol *s, int argc, t_atom *argv)
 {
     t_toggle *x = (t_toggle *)pd_new (toggle_class);
     
-    int size            = IEM_DEFAULT_SIZE;
-    int labelX          = 0;
-    int labelY          = 0;
-    int labelFontSize   = IEM_DEFAULT_FONT;
-    t_float state       = 0.0;
-    t_float nonZero     = (t_float)1.0;
-    int deep            = 0;
+    int size        = IEM_DEFAULT_SIZE;
+    t_float state   = 0.0;
+    t_float nonZero = (t_float)1.0;
+    int deep        = 0;
 
     if (argc < 13) { iemgui_deserializeDefault (cast_iem (x)); }
     else {
     //
     size            = (int)atom_getFloatAtIndex (0, argc,  argv);
-    labelX          = (int)atom_getFloatAtIndex (5, argc,  argv);
-    labelY          = (int)atom_getFloatAtIndex (6, argc,  argv);
-    labelFontSize   = (int)atom_getFloatAtIndex (8, argc,  argv);
     state           = (t_float)atom_getFloatAtIndex (12, argc, argv);
     nonZero         = (argc > 13) ? atom_getFloatAtIndex (13, argc, argv) : (t_float)1.0;
     deep            = (argc > 14);
     
     iemgui_deserializeLoadbang (cast_iem (x), (int)atom_getFloatAtIndex (1, argc, argv));
     iemgui_deserializeNames (cast_iem (x), 2, argv);
-    iemgui_deserializeFontStyle (cast_iem (x), (int)atom_getFloatAtIndex (7, argc, argv));
-    iemgui_deserializeColors (cast_iem (x), argv + 9, argv + 10, argv + 11);
+    iemgui_deserializeColors (cast_iem (x), argv + 9, argv + 10);
     //
     }
     
@@ -498,9 +491,6 @@ static void *toggle_new (t_symbol *s, int argc, t_atom *argv)
     x->x_gui.iem_canReceive = symbol_isNil (x->x_gui.iem_receive) ? 0 : 1;
     x->x_gui.iem_width      = PD_MAX (size, IEM_MINIMUM_WIDTH);
     x->x_gui.iem_height     = PD_MAX (size, IEM_MINIMUM_WIDTH);
-    x->x_gui.iem_labelX     = labelX;
-    x->x_gui.iem_labelY     = labelY;
-    x->x_gui.iem_fontSize   = labelFontSize;
     
     iemgui_checkSendReceiveLoop (cast_iem (x));
     

--- a/src/graphics/iem/g_vu.c
+++ b/src/graphics/iem/g_vu.c
@@ -488,14 +488,14 @@ static void vu_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  x->x_gui.iem_width);
     buffer_appendFloat (b,  x->x_gui.iem_height);
     buffer_appendSymbol (b, names.n_unexpandedReceive);
-    buffer_appendSymbol (b, names.n_unexpandedLabel);
-    buffer_appendFloat (b,  x->x_gui.iem_labelX);
-    buffer_appendFloat (b,  x->x_gui.iem_labelY);
-    buffer_appendFloat (b,  iemgui_serializeFontStyle (cast_iem (z)));
-    buffer_appendFloat (b,  x->x_gui.iem_fontSize);
+    buffer_appendSymbol (b, symbol_nil());                      /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
     buffer_appendSymbol (b, colors.c_symColorBackground);
-    buffer_appendSymbol (b, colors.c_symColorLabel);
-    buffer_appendFloat (b,  x->x_hasScale);
+    buffer_appendSymbol (b, color_toEncoded (0));               /* Legacy. */
+    buffer_appendFloat (b,  0);                                 /* Legacy. */
     buffer_appendFloat (b,  0);
     buffer_appendSemicolon (b);
     
@@ -625,29 +625,20 @@ static void *vu_new (t_symbol *s, int argc, t_atom *argv)
 {
     t_vu *x = (t_vu *)pd_new (vu_class);
 
-    int width           = IEM_DEFAULT_SIZE;
-    int height          = IEM_VUMETER_STEPS * IEM_VUMETER_THICKNESS;
-    int labelX          = 0;
-    int labelY          = 0;
-    int labelFontSize   = IEM_DEFAULT_FONT;
-    int hasScale        = 0;
+    int width       = IEM_DEFAULT_SIZE;
+    int height      = IEM_VUMETER_STEPS * IEM_VUMETER_THICKNESS;
 
     if (argc < 11) { iemgui_deserializeDefault (cast_iem (x)); }
     else {
     //
     width           = (int)atom_getFloatAtIndex (0,  argc, argv);
     height          = (int)atom_getFloatAtIndex (1,  argc, argv);
-    labelX          = (int)atom_getFloatAtIndex (4,  argc, argv);
-    labelY          = (int)atom_getFloatAtIndex (5,  argc, argv);
-    labelFontSize   = (int)atom_getFloatAtIndex (7,  argc, argv);
-    hasScale        = (int)atom_getFloatAtIndex (10, argc, argv);
     
     /* Note that the value of height is pitiably attribute to the send symbol. */
     /* Must be kept for backward compatibility. */
     
     iemgui_deserializeNames (cast_iem (x), 1, argv);
-    iemgui_deserializeFontStyle (cast_iem (x), (int)atom_getFloatAtIndex (6, argc, argv));
-    iemgui_deserializeColors (cast_iem (x), argv + 8, NULL, argv + 9);
+    iemgui_deserializeColors (cast_iem (x), argv + 8, NULL);
     //
     }
 
@@ -656,9 +647,6 @@ static void *vu_new (t_symbol *s, int argc, t_atom *argv)
     x->x_gui.iem_canSend    = 0;
     x->x_gui.iem_canReceive = symbol_isNil (x->x_gui.iem_receive) ? 0 : 1;
     x->x_gui.iem_width      = PD_MAX (width, IEM_MINIMUM_WIDTH);
-    x->x_gui.iem_labelX     = labelX;
-    x->x_gui.iem_labelY     = labelY;
-    x->x_gui.iem_fontSize   = labelFontSize;
         
     vu_setHeight (x, height);
     
@@ -666,8 +654,6 @@ static void *vu_new (t_symbol *s, int argc, t_atom *argv)
     
     if (x->x_gui.iem_canReceive) { pd_bind (cast_pd (x), x->x_gui.iem_receive); }
         
-    x->x_hasScale = (hasScale != 0);
-    
     inlet_new2 (x, &s_float);
     
     x->x_outletLeft  = outlet_newFloat (cast_object (x));

--- a/src/graphics/patch/g_canvas.c
+++ b/src/graphics/patch/g_canvas.c
@@ -193,7 +193,7 @@ static void canvas_coords (t_glist *glist, t_symbol *s, int argc, t_atom *argv)
     
     PD_UNUSED (err); PD_ASSERT (!err);
     
-    if (!isGOP) {   /* Allow compatbility with legacy. */
+    if (!isGOP) {   /* Allow compatibility with legacy. */
     
         glist_setBounds (glist, &bounds);
             

--- a/src/graphics/patch/g_garray.c
+++ b/src/graphics/patch/g_garray.c
@@ -751,8 +751,10 @@ static t_buffer *garray_functionData (t_gobj *z, int flags)
     buffer_appendFloat (b, 0);
     for (i = 0; i < n; i++) { buffer_appendFloat (b, w_getFloat (GARRAY_AT (i))); }
     
-    buffer_appendComma (b);
-    buffer_appendSymbol (b, sym__restore);
+    if (SAVED_DEEP (flags)) {
+        buffer_appendComma (b);
+        buffer_appendSymbol (b, sym__restore);
+    }
     
     return b;
     //

--- a/src/graphics/patch/g_gatom.c
+++ b/src/graphics/patch/g_gatom.c
@@ -35,14 +35,11 @@ struct _gatom {
     t_atom          a_atom;
     t_float         a_lowRange;
     t_float         a_highRange;
-    int             a_position;                         /* Unused but kept for compatibility. */
     t_glist         *a_owner;
     t_symbol        *a_send;
     t_symbol        *a_receive;
-    t_symbol        *a_label;                           /* Unused but kept for compatibility. */
     t_symbol        *a_unexpandedSend;
     t_symbol        *a_unexpandedReceive;
-    t_symbol        *a_unexpandedLabel;                 /* Unused but kept for compatibility. */
     t_outlet        *a_outlet;
     };
 
@@ -257,8 +254,8 @@ static void gatom_functionSave (t_gobj *z, t_buffer *b, int flags)
     buffer_appendFloat (b,  object_getWidth (cast_object (x)));
     buffer_appendFloat (b,  x->a_lowRange);
     buffer_appendFloat (b,  x->a_highRange);
-    buffer_appendFloat (b,  x->a_position);
-    buffer_appendSymbol (b, symbol_dollarToHash (symbol_emptyAsDash (x->a_unexpandedLabel)));
+    buffer_appendFloat (b,  1);                                                                 /* Legacy. */
+    buffer_appendSymbol (b, symbol_dollarToHash (symbol_emptyAsDash (&s_)));                    /* Legacy. */
     buffer_appendSymbol (b, symbol_dollarToHash (symbol_emptyAsDash (x->a_unexpandedReceive)));
     buffer_appendSymbol (b, symbol_dollarToHash (symbol_emptyAsDash (x->a_unexpandedSend)));
     if (SAVED_DEEP (flags)) { buffer_appendAtom (b, &x->a_atom); }
@@ -470,10 +467,9 @@ static void gatom_restore (t_gatom *x)
 
 static void gatom_makeObjectFile (t_gatom *x, int argc, t_atom *argv)
 {
-    int width    = (int)atom_getFloatAtIndex (2, argc, argv);
-    int position = (int)atom_getFloatAtIndex (5, argc, argv);
+    int width = (int)atom_getFloatAtIndex (2, argc, argv);
 
-    width        = PD_CLAMP (width, 0, ATOM_WIDTH_MAXIMUM);
+    width     = PD_CLAMP (width, 0, ATOM_WIDTH_MAXIMUM);
     
     object_setX (cast_object (x), atom_getFloatAtIndex (0, argc, argv));
     object_setY (cast_object (x), atom_getFloatAtIndex (1, argc, argv));
@@ -481,13 +477,11 @@ static void gatom_makeObjectFile (t_gatom *x, int argc, t_atom *argv)
 
     x->a_lowRange           = atom_getFloatAtIndex (3, argc, argv);
     x->a_highRange          = atom_getFloatAtIndex (4, argc, argv);
-    x->a_position           = position;
-    x->a_unexpandedLabel    = gatom_parse (atom_getSymbolAtIndex (6, argc, argv));
+    
     x->a_unexpandedReceive  = gatom_parse (atom_getSymbolAtIndex (7, argc, argv));
     x->a_unexpandedSend     = gatom_parse (atom_getSymbolAtIndex (8, argc, argv));
     x->a_send               = dollar_expandSymbol (x->a_unexpandedSend, x->a_owner);
     x->a_receive            = dollar_expandSymbol (x->a_unexpandedReceive, x->a_owner);
-    x->a_label              = dollar_expandSymbol (x->a_unexpandedLabel, x->a_owner);
             
     if (x->a_receive != &s_) { pd_bind (cast_pd (x), x->a_receive); }
     
@@ -528,13 +522,10 @@ static void gatom_makeObjectProceed (t_glist *glist, t_atomtype type, int argc, 
     x->a_owner              = glist;
     x->a_lowRange           = 0;
     x->a_highRange          = 0;
-    x->a_position           = 1;
     x->a_send               = &s_;
     x->a_receive            = &s_;
-    x->a_label              = &s_;
     x->a_unexpandedSend     = &s_;
     x->a_unexpandedReceive  = &s_;
-    x->a_unexpandedLabel    = &s_;
     
     if (type == A_FLOAT) {
         t_atom a;


### PR DESCRIPTION
**Proposed changes**

  - The [text define] object output a bang when interactively updated.
  - It is more consistent with [qlist] and [textfile].
  - Remove compatibility with unused properties for IEM objects.
  - It means that a ".pd" patch converted to ".pdpatch" then back to ".pd" is no more fully supported.

See #25
