### PR TITLE
Avoid to rename garrays during deencapsulation

### DIFF
--- a/src/control/list/x_listtrim.c
+++ b/src/control/list/x_listtrim.c
@@ -49,7 +49,7 @@ void *listtrim_new (t_symbol *s, int argc, t_atom *argv)
 {
     t_listtrim *x = (t_listtrim *)pd_new (listtrim_class);
     
-    x->x_outlet = outlet_newList (cast_object (x));
+    x->x_outlet = outlet_newMixed (cast_object (x));
     
     if (argc) { warning_unusedArguments (s, argc, argv); }
     

--- a/src/core/m_clipboard.c
+++ b/src/core/m_clipboard.c
@@ -172,14 +172,15 @@ void clipboard_pasteProceedLoadbang (t_glist *glist, int alreadyThere)
     }
 }
 
-int clipboard_pasteProceed (t_glist *glist, t_buffer *b, t_point *pt, int moveScalars)
+int clipboard_pasteProceed (t_glist *glist, t_buffer *b, t_point *pt, int moveScalars, int renameArrays)
 {
     int alreadyThere = glist_objectGetNumberOf (glist);
 
     glist_deselectAllProceed (glist, 0);
     
     snippet_addOffsetToLines (b, alreadyThere);
-    snippet_renameArrays (b, glist);
+    
+    if (renameArrays) { snippet_renameArrays (b, glist); }
     
         instance_loadSnippet (glist, b);
     
@@ -222,7 +223,7 @@ void clipboard_pasteRaw (t_glist *glist, int isDuplicate)
     
     if (undoable) { glist_undoAppend (glist, isDuplicate ? undoduplicate_new() : undopaste_new()); }
     
-    isDirty = clipboard_pasteProceed (glist, b, &pt, 1);
+    isDirty = clipboard_pasteProceed (glist, b, &pt, 1, 1);
     
     dsp_resume (state);
     

--- a/src/core/m_deencapsulate.c
+++ b/src/core/m_deencapsulate.c
@@ -23,7 +23,7 @@ t_undomanager *glist_undoReplaceManager (t_glist *, t_undomanager *);
 
 t_buffer *clipboard_copyProceed (t_glist *, int, int);
 
-int      clipboard_pasteProceed (t_glist *, t_buffer *, t_point *, int);
+int      clipboard_pasteProceed (t_glist *, t_buffer *, t_point *, int, int);
 
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
@@ -214,7 +214,7 @@ static void encapsulate_deencapsulatePaste (t_glist *parent, t_buffer *b, t_rect
     
     t_point pt = point_make (t1, t2);
     
-    clipboard_pasteProceed (parent, b, &pt, 0);
+    clipboard_pasteProceed (parent, b, &pt, 0, 0);
 }
 
 static void encapsulate_deencapsulateReconnect (t_connecthelper *h1, t_connecthelper *h2)


### PR DESCRIPTION
Fix possible bugs with garrays during deencapsulation.
