### PR TITLE
Use tagged version to make Wish.app

### DIFF
--- a/wish/build.sh
+++ b/wish/build.sh
@@ -32,21 +32,18 @@ embedded="${rep}/embedded"
 # ------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------
 
-# urlTcl="https://github.com/tcltk/tcl.git"
-# urlTk="https://github.com/tcltk/tk.git"
+urlTcl="https://github.com/tcltk/tcl.git"
+urlTk="https://github.com/tcltk/tk.git"
 
-urlTcl="https://github.com/Spaghettis/tcl.git"
-urlTk="https://github.com/Spaghettis/tk.git"
-
-branch="core-8-6-branch"
+tag="release"
 
 # ------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------
 
 # Get the sources.
 
-[ -e "${tcl}" ] || { git clone --depth 1 --single-branch --branch "${branch}" "${urlTcl}"; }
-[ -e "${tk}" ]  || { git clone --depth 1 --single-branch --branch "${branch}" "${urlTk}";  }
+[ -e "${tcl}" ] || { git clone -b "${tag}" --depth 1 "${urlTcl}"; }
+[ -e "${tk}" ]  || { git clone -b "${tag}" --depth 1 "${urlTk}";  }
 
 # ------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #247 

- Use the "release" tagged version. 
- Frankly i don't know why i didn't do that before.
