### PR TITLE
Compile Wish with core-8-6-branch

### DIFF
--- a/wish/build.sh
+++ b/wish/build.sh
@@ -32,18 +32,28 @@ embedded="${rep}/embedded"
 # ------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------
 
-urlTcl="https://github.com/tcltk/tcl.git"
-urlTk="https://github.com/tcltk/tk.git"
+# Get the sources.
 
-tag="release"
+# urlTcl="https://github.com/tcltk/tcl.git"
+# urlTk="https://github.com/tcltk/tk.git"
+
+# tag="release"
+
+# [ -e "${tcl}" ] || { git clone -b "${tag}" --depth 1 "${urlTcl}"; }
+# [ -e "${tk}" ]  || { git clone -b "${tag}" --depth 1 "${urlTk}";  }
 
 # ------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------
 
 # Get the sources.
 
-[ -e "${tcl}" ] || { git clone -b "${tag}" --depth 1 "${urlTcl}"; }
-[ -e "${tk}" ]  || { git clone -b "${tag}" --depth 1 "${urlTk}";  }
+urlTcl="https://github.com/nicolasdanet/tcl.git"
+urlTk="https://github.com/nicolasdanet/tk.git"
+
+branch="core-8-6-branch"
+
+[ -e "${tcl}" ] || { git clone --depth 1 --single-branch --branch "${branch}" "${urlTcl}"; }
+[ -e "${tk}" ]  || { git clone --depth 1 --single-branch --branch "${branch}" "${urlTk}";  }
 
 # ------------------------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
See #253

**Proposed changes**
 
  - Use "core-8-6-branch" instead of tag "release" to compile Wish.
  - The last source doesn't compile on macOS 10.15.7 (and i don't know since when).
  - It should be tested on other system.
  - It is really annoying to not be able to get a Tcl/Tk stable branch to be based onto.
  - Anyway a day Tcl/Tk will be not a problem anymore!
