### PR TITLE
Avoid the Dark Mode on macOS

### DIFF
--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>true</string>
 	<key>CFBundleName</key>
 	<string>Spaghettis</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Fixes #256

Opt out of Dark Mode on macOS to avoid GUI mess (Tk/Wish) with mode on.

< https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app#2993818 >
