### PR TITLE
Improve error message for audio

### DIFF
--- a/buildMac.sh
+++ b/buildMac.sh
@@ -113,7 +113,7 @@ cd "${rep}"                                                             || exit 
 echo "Codesign ..."
 
 codesign    --options runtime \
-            --entitlements ./resources/Entitlements.plist \
+            --entitlements ./resources/Spaghettis.entitlements \
             --deep \
             -f -s "-" "${app}"                                          || exit 1
 

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSRequiresAquaSystemAppearance</key>
-	<string>true</string>
 	<key>CFBundleName</key>
 	<string>Spaghettis</string>
 	<key>CFBundleDisplayName</key>
@@ -85,5 +83,9 @@
 	<string>font</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.12.0</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>true</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Spaghettis requires access to the Microphone.</string>
 </dict>
 </plist>

--- a/resources/Spaghettis.entitlements
+++ b/resources/Spaghettis.entitlements
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <!-- Required for loading unsigned plugins: -->
-        <key>com.apple.security.cs.disable-library-validation</key>
-        <true/>
-    </dict>
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
 </plist>

--- a/src/libs/core/core_audiograph.c
+++ b/src/libs/core/core_audiograph.c
@@ -120,6 +120,14 @@ t_error audiograph_check (t_audiograph *graph, int close)
     return PD_ERROR_NONE;
 }
 
+static void audiograph_invalid (int sampleRate, int i, int o)
+{
+    post_error (PD_TRANSLATE ("audio: invalid sampling rate"));                                 // --
+    
+    if (sampleRate != i) { post_error (PD_TRANSLATE ("audio: invalid input / %d Hz"), i);  }    // --
+    if (sampleRate != o) { post_error (PD_TRANSLATE ("audio: invalid output / %d Hz"), o); }    // --
+}
+
 // -----------------------------------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------------------------------
 // MARK: -
@@ -152,10 +160,13 @@ static t_error audiograph_openSimple (t_audiograph *graph,
     if (!hasInput || !hasOutput) { return PD_ERROR; }
     else {
     //
-    err |= (audiodevice_getSampleRate (&graph->g_deviceIn)  != sampleRate);
-    err |= (audiodevice_getSampleRate (&graph->g_deviceOut) != sampleRate);
+    int t0 = audiodevice_getSampleRate (&graph->g_deviceIn);
+    int t1 = audiodevice_getSampleRate (&graph->g_deviceOut);
     
-    if (err) { error_invalid (sym_audio, sym_samplerate); }
+    err |= (t0 != sampleRate);
+    err |= (t1 != sampleRate);
+    
+    if (err) { audiograph_invalid (sampleRate, t0, t1); }
     else {
     //
     audio_vectorShrinkIn (channelsIn);
@@ -222,9 +233,11 @@ static t_error audiograph_openDuplex (t_audiograph *graph,
     if (!hasIO) { return PD_ERROR; }
     else {
     //
-    err |= (audiodevice_getSampleRate (&graph->g_deviceDuplex) != sampleRate);
+    int t = audiodevice_getSampleRate (&graph->g_deviceDuplex);
     
-    if (err) { error_invalid (sym_audio, sym_samplerate); }
+    err |= (t != sampleRate);
+    
+    if (err) { audiograph_invalid (sampleRate, t, t); }
     else {
     //
     audio_vectorShrinkIn (channelsIn);


### PR DESCRIPTION
Fix #257

Improve error message when sampling rates mismatched (especially when input device is not the same as the output device).
