### PR TITLE
Use NATIVE_ARCH_ACTUAL for Xcode project

### DIFF
--- a/projects/Spaghettis.xcodeproj/project.pbxproj
+++ b/projects/Spaghettis.xcodeproj/project.pbxproj
@@ -2420,7 +2420,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -2450,7 +2450,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
 				GCC_PREPROCESSOR_DEFINITIONS = PD_BUILDING_APPLICATION;


### PR DESCRIPTION
In order to port Spaghettis to Apple Silicon later, use the native architecture to build the debug version.
Note that parts of the Belle library needs the Homebrew's FreeType < https://www.freetype.org/ >. 
Homebrew doesn't support ARM for now.
Belle's Xcode project is left x86_64 only.
